### PR TITLE
Cleanup/20200304

### DIFF
--- a/asyncstdlib/_core.py
+++ b/asyncstdlib/_core.py
@@ -72,20 +72,19 @@ async def close_temporary(
 
 
 class ScopedIter(Generic[T]):
-    """Context manager that provides iterators and cleans up any created ones"""
+    """Context manager that provides and cleans up an iterator for an iterable"""
 
-    def __init__(self, *iterables: AnyIterable[T]):
-        self._iterables = iterables
-        self._iterators: Optional[Tuple[AsyncIterator[T], ...]] = None
+    def __init__(self, iterable: AnyIterable[T]):
+        self._iterable = iterable
+        self._iterator: Optional[AsyncIterator[T]] = None
 
-    async def __aenter__(self) -> Tuple[AsyncIterator[T], ...]:
-        assert self._iterators is None, f"{self.__class__.__name__} is not re-entrant"
-        self._iterators = (*(aiter(it) for it in self._iterables),)
-        return self._iterators
+    async def __aenter__(self) -> AsyncIterator[T]:
+        assert self._iterator is None, f"{self.__class__.__name__} is not re-entrant"
+        self._iterator = aiter(self._iterable)
+        return self._iterator
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
-        for iterable, iterator in zip(self._iterables, self._iterators):
-            await close_temporary(iterator, iterable)
+        await close_temporary(self._iterator, self._iterable)
         return False
 
 

--- a/asyncstdlib/_core.py
+++ b/asyncstdlib/_core.py
@@ -7,7 +7,6 @@ from typing import (
     Union,
     Generic,
     Optional,
-    Tuple,
     Iterator,
     Awaitable,
     Callable,

--- a/asyncstdlib/builtins.py
+++ b/asyncstdlib/builtins.py
@@ -21,7 +21,6 @@ from ._core import (
     aiter,
     AnyIterable,
     ScopedIter,
-    close_temporary as _close_temporary,
     awaitify as _awaitify,
     Sentinel,
 )
@@ -113,7 +112,7 @@ async def all(iterable: AnyIterable[T]) -> bool:
     """
     Return :py:data:`True` if none of the elements of the (async) ``iterable`` are false
     """
-    async with ScopedIter(iterable) as (item_iter,):
+    async with ScopedIter(iterable) as item_iter:
         async for element in item_iter:
             if not element:
                 return False
@@ -124,7 +123,7 @@ async def any(iterable: AnyIterable[T]) -> bool:
     """
     Return :py:data:`False` if none of the elements of the (async) ``iterable`` are true
     """
-    async with ScopedIter(iterable) as (item_iter,):
+    async with ScopedIter(iterable) as item_iter:
         async for element in item_iter:
             if element:
                 return True
@@ -194,7 +193,7 @@ async def map(
     Multiple ``iterable`` may be mixed regular and async iterables.
     """
     function = _awaitify(function)
-    async with ScopedIter(zip(*iterable)) as (args_iter,):
+    async with ScopedIter(zip(*iterable)) as args_iter:
         async for args in args_iter:
             result = function(*args)
             yield await result
@@ -226,7 +225,7 @@ async def max(
         as it does not benefit from being ``async``.
         Use the builtin :py:func:`max` function instead.
     """
-    async with ScopedIter(iterable) as (item_iter,):
+    async with ScopedIter(iterable) as item_iter:
         best = await anext(item_iter, default=__MAX_DEFAULT)
         if best is __MAX_DEFAULT:
             if default is __MAX_DEFAULT:
@@ -270,7 +269,7 @@ async def min(
         as it does not benefit from being ``async``.
         Use the builtin :py:func:`min` function instead.
     """
-    async with ScopedIter(iterable) as (item_iter,):
+    async with ScopedIter(iterable) as item_iter:
         best = await anext(item_iter, default=__MAX_DEFAULT)
         if best is __MAX_DEFAULT:
             if default is __MAX_DEFAULT:
@@ -304,7 +303,7 @@ async def filter(
     The ``function`` may be a regular or async callable.
     The ``iterable`` may be a regular or async iterable.
     """
-    async with ScopedIter(iterable) as (item_iter,):
+    async with ScopedIter(iterable) as item_iter:
         if function is None:
             async for item in item_iter:
                 if item:
@@ -325,7 +324,7 @@ async def enumerate(iterable: AnyIterable[T], start=0) -> AsyncIterator[Tuple[in
     The ``iterable`` may be a regular or async iterable.
     """
     count = start
-    async with ScopedIter(iterable) as (item_iter,):
+    async with ScopedIter(iterable) as item_iter:
         async for item in item_iter:
             yield count, item
             count += 1

--- a/asyncstdlib/contextlib.py
+++ b/asyncstdlib/contextlib.py
@@ -2,6 +2,8 @@ from typing import TypeVar, Generic, AsyncGenerator, Callable
 from typing_extensions import Protocol, AsyncContextManager
 from functools import wraps
 
+from ._utility import public_module
+
 
 class ACloseable(Protocol):
     async def aclose(self):
@@ -82,7 +84,8 @@ class _AsyncGeneratorContextManager:
                 raise RuntimeError("generator did not stop after throw() in __aexit__")
 
 
-class closing(Generic[AC]):
+@public_module(__name__, "closing")
+class Closing(Generic[AC]):
     """
     Create an :term:`asynchronous context manager` to ``aclose`` some ``thing`` on exit
 
@@ -113,7 +116,11 @@ class closing(Generic[AC]):
         await self.thing.aclose()
 
 
-class nullcontext(Generic[T]):
+closing = Closing
+
+
+@public_module(__name__, "nullcontext")
+class NullContext(Generic[T]):
     """
     Create an :term:`asynchronous context manager` that only returns ``enter_result``
 
@@ -144,3 +151,6 @@ class nullcontext(Generic[T]):
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         pass
+
+
+nullcontext = NullContext

--- a/asyncstdlib/functools.py
+++ b/asyncstdlib/functools.py
@@ -33,7 +33,7 @@ async def reduce(
     and ``iterable`` contains exactly one item, it is returned without
     calling ``function``.
     """
-    async with ScopedIter(iterable) as (item_iter,):
+    async with ScopedIter(iterable) as item_iter:
         try:
             value = (
                 initial if initial is not __REDUCE_SENTINEL else await anext(item_iter)

--- a/asyncstdlib/itertools.py
+++ b/asyncstdlib/itertools.py
@@ -206,11 +206,12 @@ async def islice(iterable: AnyIterable[T], *args: Optional[int]) -> AsyncIterato
                 if _count == start:
                     break
         if stop is None:
-            async for idx, element in aenumerate(async_iter, start=start):
+            async for idx, element in aenumerate(async_iter, start=0):
                 if idx % step == 0:
                     yield element
         else:
-            async for idx, element in aenumerate(async_iter, start=start):
+            stop -= start
+            async for idx, element in aenumerate(async_iter, start=0):
                 if idx >= stop:
                     return
                 if not idx % step:

--- a/asyncstdlib/itertools.py
+++ b/asyncstdlib/itertools.py
@@ -17,7 +17,13 @@ from typing import (
 from collections import deque
 
 from ._utility import public_module
-from ._core import ScopedIter, AnyIterable, awaitify as _awaitify, Sentinel, close_temporary as _close_temporary
+from ._core import (
+    ScopedIter,
+    AnyIterable,
+    awaitify as _awaitify,
+    Sentinel,
+    close_temporary as _close_temporary,
+)
 from .builtins import anext, zip, enumerate as aenumerate, aiter as aiter
 
 T = TypeVar("T")

--- a/unittests/test_itertools.py
+++ b/unittests/test_itertools.py
@@ -88,7 +88,10 @@ async def test_compress(data, selectors):
 droptakewhile_cases = [
     (range(20), lambda x: x < 5),
     (range(20), lambda x: x > 5),
-    ([1] * 12, lambda y: y > 5),
+    ([1] * 12, lambda x: x > 5),
+    ([1, 2, 3, 4] * 4, lambda x: x < 3),
+    ([1, 2, 3, 4] * 4, lambda x: True),
+    ([1, 2, 3, 4] * 4, lambda x: False),
 ]
 
 

--- a/unittests/test_itertools.py
+++ b/unittests/test_itertools.py
@@ -119,14 +119,16 @@ async def test_takewhile(iterable, predicate):
     )
 
 
+@pytest.mark.parametrize("iterable", ((), (1, 2, 3, 4), range(25), range(500)))
+@pytest.mark.parametrize(
+    "slicing",
+    ((None, None, None), (0,), (5,), (0, 20, 3), (5, 0, 1), (3, 50, 4), (5, None, 6)),
+)
 @sync
-async def test_islice():
-    for iterable in ((), (1, 2, 3, 4), range(25), range(500)):
-        for slicing in ((0,), (5,), (None, None, None), (0, 20, 3), (5, 0, 1)):
-            print(slicing)
-            expected = list(itertools.islice(iterable, *slicing))
-            assert await a.list(a.islice(iterable, *slicing)) == expected
-            assert await a.list(a.islice(asyncify(iterable), *slicing)) == expected
+async def test_islice(iterable, slicing):
+    expected = list(itertools.islice(iterable, *slicing))
+    assert await a.list(a.islice(iterable, *slicing)) == expected
+    assert await a.list(a.islice(asyncify(iterable), *slicing)) == expected
 
 
 starmap_cases = [


### PR DESCRIPTION
Clean up of various minor errors and internal APIs.

* Signature of ``ScopedIter`` aligned with ``aiter`` to accept only one iterable.
* Cleanup of ``tee`` cannot be skipped.
* Fixed incorrect item selection when using ``islice`` with both ``start`` and ``stride``.