### PR TITLE
Addition of asynctools

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ script:
   - python -m flake8
   - |
     if [[ $TRAVIS_PYTHON_VERSION != 'pypy3'* ]]; then
-      python -m black  --target-version py36 --check asyncstdlib unittests
+      python -m black --target-version py36 --diff --check asyncstdlib unittests
     fi
   - python -m coverage run -m pytest
 after_success:

--- a/asyncstdlib/__init__.py
+++ b/asyncstdlib/__init__.py
@@ -31,6 +31,7 @@ from .itertools import (
     zip_longest,
     groupby,
 )
+from .asynctools import borrow, scoped_iter
 
 __version__ = "1.0.0"
 
@@ -71,4 +72,7 @@ __all__ = [
     "tee",
     "zip_longest",
     "groupby",
+    # asynctools
+    "borrow",
+    "scoped_iter",
 ]

--- a/asyncstdlib/_core.py
+++ b/asyncstdlib/_core.py
@@ -58,7 +58,6 @@ async def _aiter_sync(iterable: Iterable[T]) -> AsyncIterator[T]:
 
 async def close_temporary(
     iterator: AsyncIterator,
-    source: Union[AsyncIterator, AsyncIterable, Iterator, Iterable],
 ):
     """Close an ``iterator`` created from ``source`` if it is a separate object"""
     try:
@@ -79,10 +78,11 @@ class ScopedIter(Generic[T]):
     async def __aenter__(self) -> AsyncIterator[T]:
         assert self._iterator is None, f"{self.__class__.__name__} is not re-entrant"
         self._iterator = aiter(self._iterable)
+        self._iterable = None
         return self._iterator
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
-        await close_temporary(self._iterator, self._iterable)
+        await close_temporary(self._iterator)
         return False
 
 

--- a/asyncstdlib/_core.py
+++ b/asyncstdlib/_core.py
@@ -7,7 +7,6 @@ from typing import (
     Union,
     Generic,
     Optional,
-    Iterator,
     Awaitable,
     Callable,
 )

--- a/asyncstdlib/_core.py
+++ b/asyncstdlib/_core.py
@@ -56,18 +56,6 @@ async def _aiter_sync(iterable: Iterable[T]) -> AsyncIterator[T]:
         yield item
 
 
-async def close_temporary(
-    iterator: AsyncIterator,
-):
-    """Close an ``iterator`` created from ``source`` if it is a separate object"""
-    try:
-        aclose = iterator.aclose()
-    except AttributeError:
-        pass
-    else:
-        await aclose
-
-
 class ScopedIter(Generic[T]):
     """Context manager that provides and cleans up an iterator for an iterable"""
 
@@ -82,7 +70,12 @@ class ScopedIter(Generic[T]):
         return self._iterator
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
-        await close_temporary(self._iterator)
+        try:
+            aclose = self._iterator.aclose()
+        except AttributeError:
+            pass
+        else:
+            await aclose
         return False
 
 

--- a/asyncstdlib/_core.py
+++ b/asyncstdlib/_core.py
@@ -61,13 +61,12 @@ async def close_temporary(
     source: Union[AsyncIterator, AsyncIterable, Iterator, Iterable],
 ):
     """Close an ``iterator`` created from ``source`` if it is a separate object"""
-    if iterator is not source:
-        try:
-            aclose = iterator.aclose()
-        except AttributeError:
-            pass
-        else:
-            await aclose
+    try:
+        aclose = iterator.aclose()
+    except AttributeError:
+        pass
+    else:
+        await aclose
 
 
 class ScopedIter(Generic[T]):
@@ -85,6 +84,12 @@ class ScopedIter(Generic[T]):
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         await close_temporary(self._iterator, self._iterable)
         return False
+
+
+async def borrow(iterator: AsyncIterator):
+    """Borrow an async iterator for iteration, preventing it from being closed"""
+    async for item in iterator:
+        yield item
 
 
 def awaitify(

--- a/asyncstdlib/asynctools.py
+++ b/asyncstdlib/asynctools.py
@@ -1,11 +1,18 @@
-from typing import Union, AsyncIterator, TypeVar, AsyncContextManager, Optional, AsyncGenerator
+from typing import (
+    Union,
+    AsyncIterator,
+    TypeVar,
+    AsyncContextManager,
+    Optional,
+    AsyncGenerator,
+)
 
 from ._core import AnyIterable, aiter
 from .contextlib import nullcontext
 
 
-T = TypeVar('T')
-S = TypeVar('S')
+T = TypeVar("T")
+S = TypeVar("S")
 
 
 class AsyncIteratorBorrow(AsyncGenerator[T, S]):
@@ -13,7 +20,7 @@ class AsyncIteratorBorrow(AsyncGenerator[T, S]):
     Borrowed async iterator/generator, preventing to ``aclose`` the ``iterable``
     """
 
-    __slots__ = '__wrapped__', '__aiter__', '__anext__', 'asend', 'athrow'
+    __slots__ = "__wrapped__", "__aiter__", "__anext__", "asend", "athrow"
 
     def __init__(self, iterator: Union[AsyncIterator[T], AsyncGenerator[T, S]]):
         self.__wrapped__ = iterator
@@ -22,13 +29,13 @@ class AsyncIteratorBorrow(AsyncGenerator[T, S]):
             self.__anext__ = iterator.__anext__  # argument may not be an iterable!
         except (AttributeError, TypeError):
             raise TypeError(
-                'borrowing requires an async iterator ' +
-                f'with __aiter__ and __anext__ method, got {type(iterator).__name__}'
+                "borrowing requires an async iterator "
+                + f"with __aiter__ and __anext__ method, got {type(iterator).__name__}"
             ) from None
         self.__aiter__ = wrapped_iterator.__aiter__
-        if hasattr(iterator, 'asend'):
+        if hasattr(iterator, "asend"):
             self.asend = iterator.asend
-        if hasattr(iterator, 'athrow'):
+        if hasattr(iterator, "athrow"):
             self.athrow = iterator.athrow
 
     async def aclose(self):
@@ -37,7 +44,7 @@ class AsyncIteratorBorrow(AsyncGenerator[T, S]):
 
 class AsyncIteratorContext(AsyncContextManager[AsyncIterator[T]]):
 
-    __slots__ = '__wrapped__', '_iterator'
+    __slots__ = "__wrapped__", "_iterator"
 
     def __init__(self, iterable: AnyIterable[T]):
         self._iterator: Optional[AsyncIterator[T]] = aiter(iterable)
@@ -111,7 +118,6 @@ def scoped_iter(iterable: AnyIterable[T]):
     iterator = aiter(iterable)
     # The iterable cannot be closed.
     # We do not need to take care of it.
-    if not hasattr(iterator, 'aclose'):
+    if not hasattr(iterator, "aclose"):
         return nullcontext(iterator)
     return AsyncIteratorContext(iterator)
-

--- a/asyncstdlib/asynctools.py
+++ b/asyncstdlib/asynctools.py
@@ -38,6 +38,11 @@ class AsyncIteratorBorrow(AsyncGenerator[T, S]):
         if hasattr(iterator, "athrow"):
             self.athrow = iterator.athrow
 
+    def __repr__(self):
+        return (
+            f"<{self.__class__.__name__} of {self.__wrapped__!r} at 0x{(id(self)):x}>"
+        )
+
     async def aclose(self):
         pass
 

--- a/asyncstdlib/asynctools.py
+++ b/asyncstdlib/asynctools.py
@@ -2,10 +2,10 @@ from typing import (
     Union,
     AsyncIterator,
     TypeVar,
-    AsyncContextManager,
     Optional,
     AsyncGenerator,
 )
+from typing_extensions import AsyncContextManager
 
 from ._core import AnyIterable, aiter
 from .contextlib import nullcontext

--- a/asyncstdlib/asynctools.py
+++ b/asyncstdlib/asynctools.py
@@ -65,7 +65,7 @@ def borrow(iterator: AsyncIterator[T]) -> AsyncIteratorBorrow[T, None]:
     :py:meth:`~agen.aclose` is always provided and does nothing.
 
     .. seealso:: Use :py:func:`~.scoped_iter` to ensure an (async) iterable
-                 is eventually closed and only borrowed until then.
+                 is eventually closed and only :term:`borrowed <borrowing>` until then.
     """
     if isinstance(iterator, AsyncIteratorBorrow):
         return iterator

--- a/asyncstdlib/asynctools.py
+++ b/asyncstdlib/asynctools.py
@@ -1,0 +1,107 @@
+from typing import Union, AsyncIterator, TypeVar, AsyncContextManager, Optional, AsyncGenerator
+
+from ._core import AnyIterable, aiter
+from .contextlib import nullcontext
+
+
+T = TypeVar('T')
+S = TypeVar('S')
+
+
+class AsyncIteratorBorrow(AsyncGenerator[T, S]):
+    """
+    Borrowed async iterator/generator, preventing to ``aclose`` the ``iterable``
+    """
+
+    __slots__ = '__wrapped__', '__aiter__', '__anext__', 'asend', 'athrow'
+
+    def __init__(self, iterator: Union[AsyncIterator[T], AsyncGenerator[T, S]]):
+        self.__wrapped__ = iterator
+        try:
+            wrapped_iterator: AsyncGenerator[T, S] = (item async for item in iterator)
+            self.__anext__ = iterator.__anext__  # argument may not be an iterable!
+        except (AttributeError, TypeError):
+            raise TypeError(
+                'borrowing requires an async iterator ' +
+                f'with __aiter__ and __anext__ method, got {type(iterator).__name__}'
+            ) from None
+        self.__aiter__ = wrapped_iterator.__aiter__
+        if hasattr(iterator, 'asend'):
+            self.asend = iterator.asend
+        if hasattr(iterator, 'athrow'):
+            self.athrow = iterator.athrow
+
+    async def aclose(self):
+        pass
+
+
+class AsyncIteratorContext(AsyncContextManager[AsyncIterator[T]]):
+
+    __slots__ = '__wrapped__', '_iterator'
+
+    def __init__(self, iterable: AnyIterable[T]):
+        self._iterator: Optional[AsyncIterator[T]] = aiter(iterable)
+
+    async def __aenter__(self) -> AsyncIterator[T]:
+        return AsyncIteratorBorrow(self._iterator)
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        await self._iterator.aclose()
+        return False
+
+
+def borrow(iterator: AsyncIterator[T]) -> AsyncIteratorBorrow[T, None]:
+    """
+    :term:`Borrow <borrowing>` an async iterator, preventing to ``aclose`` it
+
+    The resulting iterator supports :py:meth:`~agen.asend` and
+    :py:meth:`~agen.athrow` if the initial iterator supports them as well;
+    this allows borrowing either a :py:class:`~collections.abc.AsyncIterator`
+    or :py:class:`~collections.abc.AsyncGenerator`. Regardless of input,
+    :py:meth:`~agen.aclose` is always provided and does nothing.
+    """
+    if isinstance(iterator, AsyncIteratorBorrow):
+        return iterator
+    return AsyncIteratorBorrow(iterator)
+
+
+def scoped_iter(iterable: AnyIterable[T]):
+    """
+    Context manager that provides an async iterator for an (async) ``iterable``
+
+    Roughly equivalent to combining :py:func:`~.iter` with
+    :py:class:`~.contextlib.closing`. Inside the context, the resulting
+    :term:`asynchronous iterator` is :term:`borrowed <borrowing>` to prevent
+    premature closing when passing the iterator around. Nested scoping is safe,
+    in that inner scopes automatically forfeit closing the iterator.
+
+    .. code-block:: python3
+
+        from collections import deque
+        import asyncstdlib as a
+
+        async def head_tail(iterable, leading=5, trailing=5):
+            '''Provide the first ``leading`` and last ``trailing`` items'''
+            # create async iterator valid for the entire block
+            async with scoped_iter(iterable) as async_iter:
+                # ... safely pass it on without it being closed ...
+                async for item in a.isclice(async_iter, leading):
+                    yield item
+                tail = deque(maxlen=trailing)
+                # ... and use it again in the block
+                async for item in async_iter:
+                    tail.append(item)
+            for item in tail:
+                yield item
+    """
+    # The iterable has already been borrowed.
+    # Someone else takes care of it.
+    if isinstance(iterable, AsyncIteratorBorrow):
+        return nullcontext(iterable)
+    iterator = aiter(iterable)
+    # The iterable cannot be closed.
+    # We do not need to take care of it.
+    if not hasattr(iterator, 'aclose'):
+        return nullcontext(iterator)
+    return AsyncIteratorContext(iterator)
+

--- a/asyncstdlib/asynctools.py
+++ b/asyncstdlib/asynctools.py
@@ -2,7 +2,6 @@ from typing import (
     Union,
     AsyncIterator,
     TypeVar,
-    Optional,
     AsyncGenerator,
 )
 from typing_extensions import AsyncContextManager

--- a/asyncstdlib/asynctools.py
+++ b/asyncstdlib/asynctools.py
@@ -61,7 +61,7 @@ def borrow(iterator: AsyncIterator[T]) -> AsyncIteratorBorrow[T, None]:
     The borrowed iterator supports :py:meth:`~agen.asend` and
     :py:meth:`~agen.athrow` if the underlying iterator supports them as well;
     this allows borrowing either an :py:class:`~collections.abc.AsyncIterator`
-    or :py:class:`~collections.abc.AsyncGenerator`. Regardless of iterator,
+    or :py:class:`~collections.abc.AsyncGenerator`. Regardless of iterator type,
     :py:meth:`~agen.aclose` is always provided and does nothing.
 
     .. seealso:: Use :py:func:`~.scoped_iter` to ensure an (async) iterable
@@ -101,7 +101,8 @@ def scoped_iter(iterable: AnyIterable[T]):
                 yield item
 
     Nested scoping of the same iterator is safe: inner scopes automatically
-    forfeit closing the iterator in favour of the outermost scope.
+    forfeit closing the iterator in favour of the outermost scope. This allows
+    passing the borrowed iterator to other functions that use :py:func:`scoped_iter`.
     """
     # The iterable has already been borrowed.
     # Someone else takes care of it.

--- a/asyncstdlib/asynctools.py
+++ b/asyncstdlib/asynctools.py
@@ -67,7 +67,7 @@ class AsyncIteratorContext(AsyncContextManager[AsyncIterator[T]]):
     __slots__ = "__wrapped__", "_iterator"
 
     def __init__(self, iterable: AnyIterable[T]):
-        self._iterator: Optional[AsyncIterator[T]] = aiter(iterable)
+        self._iterator: AsyncIterator[T] = aiter(iterable)
 
     async def __aenter__(self) -> AsyncIterator[T]:
         return AsyncIteratorBorrow(self._iterator)
@@ -75,6 +75,9 @@ class AsyncIteratorContext(AsyncContextManager[AsyncIterator[T]]):
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         await self._iterator.aclose()
         return False
+
+    def __repr__(self):
+        return f"<{self.__class__.__name__} of {self._iterator!r} at 0x{(id(self)):x}>"
 
 
 def borrow(iterator: AsyncIterator[T]) -> AsyncIteratorBorrow[T, None]:

--- a/asyncstdlib/builtins.py
+++ b/asyncstdlib/builtins.py
@@ -21,7 +21,6 @@ from ._core import (
     aiter,
     AnyIterable,
     ScopedIter,
-    close_temporary as _close_temporary,
     awaitify as _awaitify,
     Sentinel,
 )
@@ -160,7 +159,12 @@ async def zip(*iterables: AnyIterable[T]) -> AsyncIterator[Tuple[T, ...]]:
         return
     finally:
         for iterator in aiters:
-            await _close_temporary(iterator)
+            try:
+                aclose = iterator.aclose()
+            except AttributeError:
+                pass
+            else:
+                await aclose
 
 
 class SyncVariadic(Protocol[T, R]):

--- a/asyncstdlib/builtins.py
+++ b/asyncstdlib/builtins.py
@@ -1,4 +1,3 @@
-from builtins import zip as _zip
 from typing import (
     Iterable,
     AsyncIterable,
@@ -153,14 +152,15 @@ async def zip(*iterables: AnyIterable[T]) -> AsyncIterator[Tuple[T, ...]]:
     if not iterables:
         return
     aiters = (*(aiter(it) for it in iterables),)
+    del iterables
     try:
         while True:
             yield (*[await anext(it) for it in aiters],)
     except StopAsyncIteration:
         return
     finally:
-        for iterable, iterator in _zip(iterables, aiters):
-            await _close_temporary(iterator, iterable)
+        for iterator in aiters:
+            await _close_temporary(iterator)
 
 
 class SyncVariadic(Protocol[T, R]):

--- a/asyncstdlib/builtins.py
+++ b/asyncstdlib/builtins.py
@@ -79,9 +79,9 @@ def iter(
     :raises TypeError: if ``subject`` does not support any iteration protocol
 
     If ``sentinel`` is not given, the ``subject`` must support
-    the async iteration protocol (the :py:meth:`object.__aiter__` method),
-    the regular iteration protocol (the :py:meth:`object.__iter__` method),
-    or it must support the sequence protocol (the :py:meth:`object.__getitem__`
+    the async iteration protocol (the :py:meth:`~object.__aiter__` method),
+    the regular iteration protocol (the :py:meth:`~object.__iter__` method),
+    or it must support the sequence protocol (the :py:meth:`~object.__getitem__`
     method with integer arguments starting at 0).
     In either case, an async iterator is returned.
 
@@ -89,6 +89,9 @@ def iter(
     :py:func:`~.iter` provides an async iterator that uses ``await subject()``
     to produce new values. Once a value equals ``sentinel``, the value is discarded
     and iteration stops.
+
+    .. seealso:: Use :py:func:`~.scoped_iter` to ensure an (async) iterable
+                 is eventually closed and only :term:`borrowed <borrowing>` until then.
     """
     if sentinel is __ITER_DEFAULT:
         return aiter(subject)

--- a/asyncstdlib/contextlib.py
+++ b/asyncstdlib/contextlib.py
@@ -122,6 +122,9 @@ class Closing(Generic[AC]):
         async with a.closing(a.iter(something)) as async_iter:
             async for element in async_iter:
                 ...
+
+    .. seealso:: Use :py:func:`~.scoped_iter` to ensure an (async) iterable
+                 is eventually closed and only borrowed until then.
     """
 
     def __init__(self, thing: AC):

--- a/asyncstdlib/contextlib.py
+++ b/asyncstdlib/contextlib.py
@@ -124,7 +124,7 @@ class Closing(Generic[AC]):
                 ...
 
     .. seealso:: Use :py:func:`~.scoped_iter` to ensure an (async) iterable
-                 is eventually closed and only borrowed until then.
+                 is eventually closed and only :term:`borrowed <borrowing>` until then.
     """
 
     def __init__(self, thing: AC):
@@ -204,7 +204,7 @@ class ExitStack:
 
     .. note::
 
-        Unlike :py:class:`contextlib.AsyncExitStack`, this is class provides
+        Unlike :py:class:`contextlib.AsyncExitStack`, this class provides
         an :term:`async neutral` version of the :py:class:`contextlib.ExitStack`.
         There are no separate methods to distinguish async and regular arguments.
     """

--- a/asyncstdlib/itertools.py
+++ b/asyncstdlib/itertools.py
@@ -1,4 +1,3 @@
-from builtins import zip as _zip
 from typing import (
     Any,
     TypeVar,
@@ -390,6 +389,7 @@ async def zip_longest(
         return
     fill_iter = aiter(_repeat(fillvalue))
     async_iters = list(aiter(it) for it in iterables)
+    del iterables
     try:
         remaining = len(async_iters)
         while True:
@@ -409,8 +409,8 @@ async def zip_longest(
             yield tuple(values)
     finally:
         await fill_iter.aclose()
-        for iterable, iterator in _zip(iterables, async_iters):
-            await _close_temporary(iterator, iterable)
+        for iterator in async_iters:
+            await _close_temporary(iterator)
 
 
 async def identity(x: T) -> T:

--- a/asyncstdlib/itertools.py
+++ b/asyncstdlib/itertools.py
@@ -22,7 +22,6 @@ from ._core import (
     AnyIterable,
     awaitify as _awaitify,
     Sentinel,
-    close_temporary as _close_temporary,
     borrow as _borrow,
 )
 from .builtins import anext, zip, enumerate as aenumerate, aiter as aiter
@@ -410,7 +409,12 @@ async def zip_longest(
     finally:
         await fill_iter.aclose()
         for iterator in async_iters:
-            await _close_temporary(iterator)
+            try:
+                aclose = iterator.aclose()
+            except AttributeError:
+                pass
+            else:
+                await aclose
 
 
 async def identity(x: T) -> T:

--- a/asyncstdlib/itertools.py
+++ b/asyncstdlib/itertools.py
@@ -24,6 +24,7 @@ from ._core import (
     awaitify as _awaitify,
     Sentinel,
     close_temporary as _close_temporary,
+    borrow as _borrow,
 )
 from .builtins import anext, zip, enumerate as aenumerate, aiter as aiter
 
@@ -202,7 +203,7 @@ async def islice(iterable: AnyIterable[T], *args: Optional[int]) -> AsyncIterato
     async with ScopedIter(iterable) as async_iter:
         # always consume the first ``start - 1`` items, even if the slice is empty
         if start > 0:
-            async for _count, element in aenumerate(async_iter, start=1):
+            async for _count, element in aenumerate(_borrow(async_iter), start=1):
                 if _count == start:
                     break
         if stop is None:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -94,7 +94,12 @@ html_theme = 'alabaster'
 # further.  For a list of options available for each theme, see the
 # documentation.
 #
-# html_theme_options = {}
+html_theme_options = {
+    "description": "The missing async toolbox",
+    'github_user': 'maxfischer2781',
+    'github_repo': 'asyncstdlib',
+    "fixed_sidebar": True,
+}
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -104,13 +104,12 @@ an active event loop. This is not given when garbage collection finalizes an
 async iterable via its :py:meth:`~object.__del__` method. Thus, async iterators
 should be cleaned up deterministically whenever possible (see `PEP 533`_ for details).
 
-Whenever an async iterator of :py:mod:`asyncstdlib` creates a temporary
-async iterator [#tempiter]_ during iteration, it assumes sole ownership of this iterator.
-It guarantees to clean up such temporary async iterators as soon as
+All async iterators of :py:mod:`asyncstdlib` that work on other iterators
+assume sole ownership of the iterators passed to them.
+Passed in async iterators are guaranteed to :py:meth:`~agen.aclose` as soon as
 the :py:mod:`asyncstdlib` async iterator itself is cleaned up.
-
-.. [#tempiter] An iterator ``aiter = a.iter(source)`` is assumed to be temporary if
-         it is a new object, that is ``aiter is not source`` holds true.
+Use :py:func:`asyncstdlib.asynctools.borrow` to prevent automatic cleanup,
+and :py:func:`asyncstdlib.asynctools.scoped_iter` to safely guarantee cleanup yourself.
 
 .. _PEP 533: https://www.python.org/dev/peps/pep-0533/
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -30,6 +30,7 @@ The missing ``async`` toolbox
    source/api/functools
    source/api/contextlib
    source/api/itertools
+   source/api/asynctools
    source/glossary
 
 The ``asyncstdlib`` library re-implements functions and classes of the Python

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -73,6 +73,18 @@ functions and classes directly.
 For example, :py:mod:`asyncstdlib.builtins.enumerate` is also available
 as ``asyncstdlib.enumerate``.
 
+The Async Library Module
+========================
+
+The core toolset used by :py:mod:`asyncstdlib` itself is available
+as a separate submodule.
+
+:py:mod:`asyncstdlib.asynctools`
+    Replicates any :py:mod:`itertools` that benefit from being asynchronous,
+    such as :py:func:`~asyncstdlib.itertools.cycle`,
+    :py:func:`~asyncstdlib.itertools.chain`,
+    or :py:func:`~asyncstdlib.itertools.accumulate`.
+
 Async Neutral Arguments
 =======================
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -121,8 +121,8 @@ All async iterators of :py:mod:`asyncstdlib` that work on other iterators
 assume sole ownership of the iterators passed to them.
 Passed in async iterators are guaranteed to :py:meth:`~agen.aclose` as soon as
 the :py:mod:`asyncstdlib` async iterator itself is cleaned up.
-Use :py:func:`asyncstdlib.asynctools.borrow` to prevent automatic cleanup,
-and :py:func:`asyncstdlib.asynctools.scoped_iter` to safely guarantee cleanup yourself.
+Use :py:func:`~asyncstdlib.asynctools.borrow` to prevent automatic cleanup,
+and :py:func:`~asyncstdlib.asynctools.scoped_iter` to guarantee cleanup in custom code.
 
 .. _PEP 533: https://www.python.org/dev/peps/pep-0533/
 

--- a/docs/source/api/asynctools.rst
+++ b/docs/source/api/asynctools.rst
@@ -1,0 +1,14 @@
+======================
+The asynctools library
+======================
+
+.. py:module:: asyncstdlib.asynctools
+    :synopsis: generic asynctools
+
+Iterator lifetime
+=================
+
+.. autofunction:: borrow(iterator: async iter T) -> async iter T
+
+.. autofunction:: scoped_iter(iterable: (async) iter T)
+    :async-with: :async iter T

--- a/docs/source/api/asynctools.rst
+++ b/docs/source/api/asynctools.rst
@@ -5,6 +5,8 @@ The asynctools library
 .. py:module:: asyncstdlib.asynctools
     :synopsis: generic asynctools
 
+.. versionadded:: 1.1.0
+
 Iterator lifetime
 =================
 

--- a/docs/source/api/asynctools.rst
+++ b/docs/source/api/asynctools.rst
@@ -3,7 +3,12 @@ The asynctools library
 ======================
 
 .. py:module:: asyncstdlib.asynctools
-    :synopsis: generic asynctools
+    :synopsis: core asynctools variants
+
+The :py:mod:`asyncstdlib.asynctools` library implements the core toolset used by
+:py:mod:`asyncstdlib` itself.
+All documented members of this module are separate from internal implementation
+and stable regardless of :py:mod:`asyncstdlib` internals.
 
 .. versionadded:: 1.1.0
 

--- a/docs/source/api/contextlib.rst
+++ b/docs/source/api/contextlib.rst
@@ -23,7 +23,7 @@ Context Managers
 
     .. versionadded:: 1.1.0
 
-.. py:function:: contextmanager(func: (...) → async iter T)(...)
+.. py:function:: contextmanager(func: (...) → async iter T) (...)
     :async-with: :T
     :noindex:
 

--- a/docs/source/api/functools.rst
+++ b/docs/source/api/functools.rst
@@ -27,9 +27,10 @@ Both :py:func:`~asyncstdlib.functools.lru_cache`
 and :py:func:`~asyncstdlib.functools.cached_property`
 of :py:mod:`asyncstdlib` work only with async callables
 (they are not :term:`async neutral`).
-Notably, this includes regular callables that return an :term:`awaitable`.
+Notably, this includes regular callables that return an :term:`awaitable`,
+such as an ``async def`` function wrapped by :py:func:`~functools.partial`.
 
-.. autofunction:: cached_property
+.. autofunction:: cached_property(getter: (Self) → await T)
     :decorator:
 
     .. versionadded:: 1.1.0
@@ -45,11 +46,17 @@ can be applied as a decorator, both with and without arguments:
         request = await asynclib.get(url)
         return request.body()
 
-.. autofunction:: lru_cache(maxsize: int = 128, typed: bool = False)
+    @a.lru_cache(maxsize=32)
+    async def get_pep(num):
+        url = f'http://www.python.org/dev/peps/pep-{num:04}/'
+        request = await asynclib.get(url)
+        return request.body()
+
+.. autofunction:: lru_cache(maxsize: ?int = 128, typed: bool = False)
     :decorator:
 
 The cache tracks *call argument patterns* and maps them to observed return values.
-A pattern is an *ordered* representation of positional and keyword arguments;
+A pattern is an *ordered* representation of provided positional and keyword arguments;
 notably, this disregards default arguments, as well as any overlap between
 positional and keyword arguments.
 This means that for a function ``f(a, b)``, the calls ``f(1, 2)``, ``f(a=1, b=2)``

--- a/docs/source/api/itertools.rst
+++ b/docs/source/api/itertools.rst
@@ -42,7 +42,7 @@ Iterator filtering
     :async-for: :T
     :noindex:
 
-.. autofunction:: islice(iterable: (async) iter T, start: int, stop: int [, step: int])
+.. autofunction:: islice(iterable: (async) iter T, start: int, stop: int , step: int =m1)
     :async-for: :T
 
 Iterator transforming

--- a/docs/source/glossary.rst
+++ b/docs/source/glossary.rst
@@ -9,7 +9,17 @@ Glossary of Terms
 
 .. glossary::
 
-   Async Neutral
+   async neutral
       An object that may provide either of a regular or asynchronous implementation.
       For example, an async neutral iterable may support either regular
       ``for _ in iterable`` or asynchronous ``async for _ in iterable`` iteration.
+
+   borrowing
+   borrowed object
+      Many ``async`` object need to be cleaned up explicitly – for example,
+      an :term:`asynchronous iterator` should generally be ``aclose``d after use
+      (see `PEP 533`_ for details). When *borrowing* such an object, the original
+      owner assures that it will clean up the object. As such, a *borrowed object*
+      can only be cleaned up by the original owner.
+
+.. _PEP 533: https://www.python.org/dev/peps/pep-0533/

--- a/docs/source/glossary.rst
+++ b/docs/source/glossary.rst
@@ -16,7 +16,7 @@ Glossary of Terms
 
    borrowing
    borrowed object
-      Many ``async`` object need to be cleaned up explicitly – for example,
+      Many ``async`` objects need to be cleaned up explicitly – for example,
       an :term:`asynchronous iterator` should generally be ``aclose``\ d after use
       (see `PEP 533`_ for details). When *borrowing* such an object to a temporary
       owner, the original owner guarantees to clean up the object but prevents the

--- a/docs/source/glossary.rst
+++ b/docs/source/glossary.rst
@@ -17,9 +17,9 @@ Glossary of Terms
    borrowing
    borrowed object
       Many ``async`` object need to be cleaned up explicitly – for example,
-      an :term:`asynchronous iterator` should generally be ``aclose``d after use
-      (see `PEP 533`_ for details). When *borrowing* such an object, the original
-      owner assures that it will clean up the object. As such, a *borrowed object*
-      can only be cleaned up by the original owner.
+      an :term:`asynchronous iterator` should generally be ``aclose``\ d after use
+      (see `PEP 533`_ for details). When *borrowing* such an object to a temporary
+      owner, the original owner guarantees to clean up the object but prevents the
+      temporary owner from doing.
 
 .. _PEP 533: https://www.python.org/dev/peps/pep-0533/

--- a/unittests/test_asynctools.py
+++ b/unittests/test_asynctools.py
@@ -1,4 +1,3 @@
-import pytest
 import asyncstdlib as a
 
 from .utility import sync, asyncify

--- a/unittests/test_asynctools.py
+++ b/unittests/test_asynctools.py
@@ -1,0 +1,20 @@
+import pytest
+import asyncstdlib as a
+
+from .utility import sync, asyncify
+
+
+@sync
+async def test_nested_lifetime():
+    async_iterable = asyncify(range(10))
+    values = []
+    async with a.scoped_iter(async_iterable) as a1:
+        values.append(await a.anext(a1))
+        async with a.scoped_iter(a1) as a2:
+            values.append(await a.anext(a2))
+            print(a2)
+        print(a1)
+        # original iterator is not closed by inner scope
+        async for value in a1:
+            values.append(value)
+    assert values == list(range(10))

--- a/unittests/test_asynctools.py
+++ b/unittests/test_asynctools.py
@@ -58,6 +58,7 @@ async def test_borrow_iterable():
     values.append(await a.anext(a.borrow(async_iterable)))
     assert values == [0, 1]
 
+
 @sync
 async def test_borrow_misuse():
     with pytest.raises(TypeError):

--- a/unittests/test_asynctools.py
+++ b/unittests/test_asynctools.py
@@ -1,3 +1,5 @@
+import pytest
+
 import asyncstdlib as a
 
 from .utility import sync, asyncify
@@ -55,3 +57,8 @@ async def test_borrow_iterable():
         values.append(await a.anext(a1))
     values.append(await a.anext(a.borrow(async_iterable)))
     assert values == [0, 1]
+
+@sync
+async def test_borrow_misuse():
+    with pytest.raises(TypeError):
+        a.borrow([1, 2, 3])

--- a/unittests/test_asynctools.py
+++ b/unittests/test_asynctools.py
@@ -34,3 +34,24 @@ async def test_borrow_explicitly():
     async for value in async_iterable:
         values.append(value)
     assert values == list(range(10))
+
+
+class Uncloseable:
+    def __init__(self, iterator):
+        self.iterator = iterator
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        return await a.anext(self.iterator)
+
+
+@sync
+async def test_borrow_iterable():
+    async_iterable = Uncloseable(asyncify(range(10)))
+    values = []
+    async with a.scoped_iter(async_iterable) as a1:
+        values.append(await a.anext(a1))
+    values.append(await a.anext(a.borrow(async_iterable)))
+    assert values == [0, 1]

--- a/unittests/test_asynctools.py
+++ b/unittests/test_asynctools.py
@@ -17,3 +17,20 @@ async def test_nested_lifetime():
         async for value in a1:
             values.append(value)
     assert values == list(range(10))
+
+
+@sync
+async def test_borrow_explicitly():
+    async_iterable = asyncify(range(10))
+    values = []
+    borrowed_aiterable = a.borrow(async_iterable)
+    values.append(await a.anext(async_iterable))
+    values.append(await a.anext(borrowed_aiterable))
+    await a.borrow(borrowed_aiterable).aclose()
+    values.append(await a.anext(borrowed_aiterable))
+    await borrowed_aiterable.aclose()
+    values.append(await a.anext(async_iterable))
+    assert values == list(range(4))
+    async for value in async_iterable:
+        values.append(value)
+    assert values == list(range(10))

--- a/unittests/test_helpers.py
+++ b/unittests/test_helpers.py
@@ -23,7 +23,7 @@ def test_slot_get():
 
 
 @sync
-async def test_close_temporary_graceful():
+async def test_scoped_iter_graceful():
     class AIterator:
         async def __anext__(self):
             return 1
@@ -36,9 +36,8 @@ async def test_close_temporary_graceful():
             return AIterator()
 
     async_iterable = AIterable()
-    async_iterator = _core.aiter(async_iterable)
-    # test that no error from calling the missing `aclose` is thrown
-    assert async_iterator is not async_iterable
-    assert (await async_iterator.__anext__()) == 1
-    await _core.close_temporary(async_iterator)
+    async with _core.ScopedIter(async_iterable) as async_iterator:
+        # test that no error from calling the missing `aclose` is thrown
+        assert async_iterator is not async_iterable
+        assert (await async_iterator.__anext__()) == 1
     assert (await async_iterator.__anext__()) == 1

--- a/unittests/test_helpers.py
+++ b/unittests/test_helpers.py
@@ -40,5 +40,5 @@ async def test_close_temporary_graceful():
     # test that no error from calling the missing `aclose` is thrown
     assert async_iterator is not async_iterable
     assert (await async_iterator.__anext__()) == 1
-    await _core.close_temporary(async_iterator, async_iterable)
+    await _core.close_temporary(async_iterator)
     assert (await async_iterator.__anext__()) == 1


### PR DESCRIPTION
This PR adds a separate subpackage with the core tools of ``asyncstdlib`` itself. Changes include:

* deterministic async iterable cleanup via ``scoped_iter`` and ``borrow`` (see #1),
* expanded docs to reference new toolset where appropriate.