### PR TITLE
Lifetime of nested borrowing

### DIFF
--- a/asyncstdlib/asynctools.py
+++ b/asyncstdlib/asynctools.py
@@ -74,8 +74,8 @@ class _AsyncIteratorContext(AsyncContextManager[AsyncIterator[T]]):
 
     __slots__ = "_borrowed_iter", "_iterator"
 
-    def __init__(self, iterable: AnyIterable[T]):
-        self._iterator: AsyncIterator[T] = aiter(iterable)
+    def __init__(self, iterable: AsyncIterator[T]):
+        self._iterator: AsyncIterator[T] = iterable
         self._borrowed_iter = None
 
     async def __aenter__(self) -> AsyncIterator[T]:

--- a/asyncstdlib/asynctools.py
+++ b/asyncstdlib/asynctools.py
@@ -158,9 +158,9 @@ def scoped_iter(iterable: AnyIterable[T]):
             for item in tail:
                 yield item
 
-    Nested scoping of the same iterator is safe: inner scopes automatically
-    forfeit closing the iterator in favour of the outermost scope. This allows
-    passing the borrowed iterator to other functions that use :py:func:`scoped_iter`.
+    Nested scoping of the same iterator is safe: inner scopes automatically forfeit
+    closing the underlying iterator in favour of the outermost scope. This allows
+    passing the scoped iterator to other functions that use :py:func:`scoped_iter`.
     """
     # The iterable has already been borrowed.
     # Do not unwrap it to preserve method forwarding.

--- a/asyncstdlib/asynctools.py
+++ b/asyncstdlib/asynctools.py
@@ -73,6 +73,8 @@ class _BorrowedAsyncIterator(AsyncGenerator[T, S]):
 
 
 class _ScopedAsyncIterator(_BorrowedAsyncIterator[T, S]):
+    __slots__ = ()
+
     def __repr__(self):
         return f"<asyncstdlib.scoped_iter of {self.__wrapped__!r} at 0x{(id(self)):x}>"
 

--- a/docs/source/glossary.rst
+++ b/docs/source/glossary.rst
@@ -20,6 +20,6 @@ Glossary of Terms
       an :term:`asynchronous iterator` should generally be ``aclose``\ d after use
       (see `PEP 533`_ for details). When *borrowing* such an object to a temporary
       owner, the original owner guarantees to clean up the object but prevents the
-      temporary owner from doing.
+      temporary owner from doing so.
 
 .. _PEP 533: https://www.python.org/dev/peps/pep-0533/

--- a/unittests/test_asynctools.py
+++ b/unittests/test_asynctools.py
@@ -5,7 +5,7 @@ import asyncstdlib as a
 from .utility import sync, asyncify
 
 
-CLOSED = 'closed'
+CLOSED = "closed"
 
 
 @sync


### PR DESCRIPTION
This PR defines the lifetime of nested borrowings. Major changes include:

* A ``scoped_iter`` lives as long as its block.
* A ``borrowed`` iter lives until ``aclose``d.