### PR TITLE
Python 3.9 feature parity

### DIFF
--- a/asyncstdlib/__init__.py
+++ b/asyncstdlib/__init__.py
@@ -16,7 +16,7 @@ from .builtins import (
     set,
     tuple,
 )
-from .functools import reduce, lru_cache, cached_property
+from .functools import reduce, lru_cache, cache, cached_property
 from .contextlib import closing, contextmanager, nullcontext, ExitStack
 from .itertools import (
     accumulate,
@@ -54,6 +54,7 @@ __all__ = [
     # functools
     "reduce",
     "lru_cache",
+    "cache",
     "cached_property",
     # contextlib
     "closing",

--- a/asyncstdlib/_lrucache.py
+++ b/asyncstdlib/_lrucache.py
@@ -65,7 +65,7 @@ class LRUAsyncCallable(Protocol[R]):
 
 
 @public_module("asyncstdlib.functools")
-def lru_cache(maxsize: int = 128, typed: bool = False):
+def lru_cache(maxsize: Optional[int] = 128, typed: bool = False):
     """
     Least Recently Used cache for async functions
 

--- a/asyncstdlib/_lrucache.py
+++ b/asyncstdlib/_lrucache.py
@@ -76,7 +76,10 @@ class LRUAsyncCallable(Protocol[R]):
         """Get the parameters of the cache"""
 
     def cache_info(self) -> CacheInfo:
-        """Get the current performance and boundary of the cache"""
+        """
+        Get the current performance and boundary of the cache
+        as a :py:class:`~typing.NamedTuple`
+        """
 
     def cache_clear(self) -> None:
         """Evict all call argument patterns and their results from the cache"""

--- a/asyncstdlib/_lrucache.py
+++ b/asyncstdlib/_lrucache.py
@@ -54,7 +54,9 @@ class CacheParameters(TypedDict):
     meaning it cannot be unpacked in assignments.
     """
 
+    #: The maximum number of cache entries or :py:data:`None` for an unbounded cache
     maxsize: Optional[int]
+    #: Whether values of different type are always treated as distinct
     typed: bool
 
 

--- a/asyncstdlib/_lrucache.py
+++ b/asyncstdlib/_lrucache.py
@@ -231,7 +231,7 @@ def _unbound_lru(
 
 
 def _bounded_lru(
-    function: Callable[..., Awaitable[R]], typed: bool, maxsize: int,
+    function: Callable[..., Awaitable[R]], typed: bool, maxsize: int
 ) -> LRUAsyncCallable[R]:
     """Wrap the async ``function`` in an async LRU cache with fixed capacity"""
     # local lookup

--- a/asyncstdlib/builtins.py
+++ b/asyncstdlib/builtins.py
@@ -185,7 +185,7 @@ class AsyncVariadic(Protocol[T, R]):
 
 
 async def map(
-    function: Union[SyncVariadic, AsyncVariadic], *iterable: AnyIterable[T],
+    function: Union[SyncVariadic, AsyncVariadic], *iterable: AnyIterable[T]
 ) -> AsyncIterator[R]:
     r"""
     An async iterator mapping an (async) function to items from (async) iterables

--- a/asyncstdlib/functools.py
+++ b/asyncstdlib/functools.py
@@ -6,7 +6,14 @@ from ._utility import public_module
 
 from ._lrucache import lru_cache, CacheInfo, LRUAsyncCallable
 
-__all__ = ["cache", "lru_cache", "CacheInfo", "LRUAsyncCallable", "reduce", "cached_property"]
+__all__ = [
+    "cache",
+    "lru_cache",
+    "CacheInfo",
+    "LRUAsyncCallable",
+    "reduce",
+    "cached_property",
+]
 
 
 T = TypeVar("T")

--- a/asyncstdlib/functools.py
+++ b/asyncstdlib/functools.py
@@ -6,10 +6,21 @@ from ._utility import public_module
 
 from ._lrucache import lru_cache, CacheInfo, LRUAsyncCallable
 
-__all__ = ["lru_cache", "CacheInfo", "LRUAsyncCallable", "reduce", "cached_property"]
+__all__ = ["cache", "lru_cache", "CacheInfo", "LRUAsyncCallable", "reduce", "cached_property"]
 
 
 T = TypeVar("T")
+R = TypeVar("R")
+
+
+def cache(user_function: Callable[..., Awaitable[R]]) -> LRUAsyncCallable[R]:
+    """
+    Simple unbounded cache, memoization,  for ``async`` functions
+
+    This is a convenience function, equivalent to :py:func:``~.lru_cache``
+    with a ``maxsize`` of :py:data:`None`.
+    """
+    return lru_cache(maxsize=None)(user_function)
 
 
 __REDUCE_SENTINEL = Sentinel("<no default>")

--- a/asyncstdlib/functools.py
+++ b/asyncstdlib/functools.py
@@ -4,12 +4,13 @@ from ._core import ScopedIter, awaitify as _awaitify, Sentinel
 from .builtins import anext, AnyIterable
 from ._utility import public_module
 
-from ._lrucache import lru_cache, CacheInfo, LRUAsyncCallable
+from ._lrucache import lru_cache, CacheInfo, CacheParameters, LRUAsyncCallable
 
 __all__ = [
     "cache",
     "lru_cache",
     "CacheInfo",
+    "CacheParameters",
     "LRUAsyncCallable",
     "reduce",
     "cached_property",
@@ -22,9 +23,9 @@ R = TypeVar("R")
 
 def cache(user_function: Callable[..., Awaitable[R]]) -> LRUAsyncCallable[R]:
     """
-    Simple unbounded cache, memoization,  for ``async`` functions
+    Simple unbounded cache, aka memoization,  for async functions
 
-    This is a convenience function, equivalent to :py:func:``~.lru_cache``
+    This is a convenience function, equivalent to :py:func:`~.lru_cache`
     with a ``maxsize`` of :py:data:`None`.
     """
     return lru_cache(maxsize=None)(user_function)

--- a/asyncstdlib/itertools.py
+++ b/asyncstdlib/itertools.py
@@ -264,7 +264,7 @@ async def takewhile(
 
 
 async def tee_peer(
-    iterator: AsyncIterator[T], buffer: Deque[T], peers: List[Deque[T]], cleanup: bool,
+    iterator: AsyncIterator[T], buffer: Deque[T], peers: List[Deque[T]], cleanup: bool
 ) -> AsyncGenerator[T, None]:
     try:
         while True:
@@ -327,9 +327,7 @@ class Tee(Generic[T]):
     the iterators are safe if there is only ever one single "most advanced" iterator.
     """
 
-    def __init__(
-        self, iterable: AnyIterable[T], n: int = 2,
-    ):
+    def __init__(self, iterable: AnyIterable[T], n: int = 2):
         self._iterator = aiter(iterable)
         _cleanup = self._iterator is iterable
         self._buffers = [deque() for _ in range(n)]
@@ -474,9 +472,9 @@ async def groupby(  # noqa: F811
     exhausted = False
     # `current_*`: buffer for key/value the current group peeked beyond its end
     current_key = current_value = nothing = object()  # type: Any
-    make_key: Callable[[T], Awaitable[R]] = _awaitify(
-        key
-    ) if key is not None else identity
+    make_key: Callable[[T], Awaitable[R]] = (
+        _awaitify(key) if key is not None else identity
+    )
     async with ScopedIter(iterable) as async_iter:
         # fast-forward mode: advance to the next group
         async def seek_group() -> AsyncIterator[T]:

--- a/docs/source/api/functools.rst
+++ b/docs/source/api/functools.rst
@@ -55,7 +55,7 @@ can be applied as a decorator, both with and without arguments:
 .. autofunction:: cache
     :decorator:
 
-    .. versionadded:: 1.1.0
+    .. versionadded:: 1.2.0
 
 .. autofunction:: lru_cache(maxsize: ?int = 128, typed: bool = False)
     :decorator:
@@ -88,6 +88,12 @@ the ``__wrapped__`` callable may be wrapped with a new cache of different size.
 
     .. automethod:: cache_info() -> CacheInfo
 
+    .. automethod:: cache_parameters() -> CacheParameters
+
+    .. versionadded:: 1.2.0
+
+        The :py:meth:`~.cache_parameters` method.
+
 
 .. autoclass:: CacheInfo
 
@@ -106,3 +112,16 @@ the ``__wrapped__`` callable may be wrapped with a new cache of different size.
     .. py:attribute:: currsize
 
         The current number of cache entries
+
+
+.. autoclass:: CacheParameters(*, maxsize, typed)
+
+    .. py:attribute:: ["maxsize"]
+
+        The maximum number of cache entries or :py:data:`None` for an unbounded cache
+
+    .. py:attribute:: ["typed"]
+
+        Whether values of different type are always treated as distinct
+
+    .. versionadded:: 1.2.0

--- a/docs/source/api/functools.rst
+++ b/docs/source/api/functools.rst
@@ -52,6 +52,11 @@ can be applied as a decorator, both with and without arguments:
         request = await asynclib.get(url)
         return request.body()
 
+.. autofunction:: cache
+    :decorator:
+
+    .. versionadded:: 1.1.0
+
 .. autofunction:: lru_cache(maxsize: ?int = 128, typed: bool = False)
     :decorator:
 

--- a/docs/source/api/functools.rst
+++ b/docs/source/api/functools.rst
@@ -86,42 +86,10 @@ the ``__wrapped__`` callable may be wrapped with a new cache of different size.
 
     .. automethod:: cache_clear()
 
-    .. automethod:: cache_info() -> CacheInfo
+    .. automethod:: cache_info() -> (hits=..., misses=..., maxsize=..., currsize=...)
 
-    .. automethod:: cache_parameters() -> CacheParameters
+    .. automethod:: cache_parameters() -> {"maxsize": ..., "typed": ...}
 
     .. versionadded:: 1.2.0
 
         The :py:meth:`~.cache_parameters` method.
-
-
-.. autoclass:: CacheInfo
-
-    .. py:attribute:: hits
-
-        Number of hits so far, i.e. results read from the cache
-
-    .. py:attribute:: misses
-
-        Number of misses, i.e. freshly computed results
-
-    .. py:attribute:: maxsize
-
-        The maximum number of cache entries or :py:data:`None` for an unbounded cache
-
-    .. py:attribute:: currsize
-
-        The current number of cache entries
-
-
-.. autoclass:: CacheParameters(*, maxsize, typed)
-
-    .. py:attribute:: ["maxsize"]
-
-        The maximum number of cache entries or :py:data:`None` for an unbounded cache
-
-    .. py:attribute:: ["typed"]
-
-        Whether values of different type are always treated as distinct
-
-    .. versionadded:: 1.2.0

--- a/docs/source/api/functools.rst
+++ b/docs/source/api/functools.rst
@@ -52,12 +52,12 @@ can be applied as a decorator, both with and without arguments:
         request = await asynclib.get(url)
         return request.body()
 
-.. autofunction:: cache
+.. autofunction:: cache((...) -> await R)
     :decorator:
 
     .. versionadded:: 1.2.0
 
-.. autofunction:: lru_cache(maxsize: ?int = 128, typed: bool = False)
+.. autofunction:: lru_cache(maxsize: ?int = 128, typed: bool = False)((...) -> await R)
     :decorator:
 
 The cache tracks *call argument patterns* and maps them to observed return values.
@@ -82,7 +82,7 @@ the ``__wrapped__`` callable may be wrapped with a new cache of different size.
 
         The callable wrapped by this cache
 
-    .. automethod:: __call__(...) -> R
+    .. automethod:: __call__(...) -> await R
 
     .. automethod:: cache_clear()
 

--- a/unittests/test_functools.py
+++ b/unittests/test_functools.py
@@ -277,3 +277,26 @@ async def test_cache():
         pingpong.cache_clear()
         assert pingpong.cache_info().hits == 0
         assert pingpong.cache_info().misses == 0
+
+
+metadata_cases = [
+    (a.cache, None),
+    (lambda func: a.lru_cache(None)(func), None),
+    (lambda func: a.lru_cache(0)(func), 0),
+    (lambda func: a.lru_cache(1)(func), 1),
+    (lambda func: a.lru_cache(256)(func), 256),
+]
+
+
+@pytest.mark.parametrize("cache, maxsize", metadata_cases)
+def test_caches_metadata(cache, maxsize):
+    @cache
+    async def pingpong(*args, **kwargs):
+        return args, kwargs
+
+    assert pingpong.cache_info().maxsize == pingpong.cache_parameters()["maxsize"]
+    assert not pingpong.cache_parameters()["typed"]
+    # state for unfilled cache should always be the same
+    assert pingpong.cache_info().hits == 0
+    assert pingpong.cache_info().misses == 0
+    assert pingpong.cache_info().currsize == 0

--- a/unittests/test_functools.py
+++ b/unittests/test_functools.py
@@ -78,7 +78,7 @@ async def test_reduce():
             assert await a.reduce(
                 reducer, itertype([0, 1, 2, 3, 4, 0, -5])
             ) == functools.reduce(lambda x, y: x + y, [0, 1, 2, 3, 4, 0, -5])
-            assert await a.reduce(reducer, itertype([1]), 23,) == functools.reduce(
+            assert await a.reduce(reducer, itertype([1]), 23) == functools.reduce(
                 lambda x, y: x + y, [1], 23
             )
             assert await a.reduce(reducer, itertype([12])) == functools.reduce(

--- a/unittests/test_itertools.py
+++ b/unittests/test_itertools.py
@@ -157,9 +157,7 @@ async def ayield_exactly(count: int):
 
 
 @sync
-@pytest.mark.parametrize(
-    "slicing", ((0,), (5,), (0, 20, 3), (5, 0, 1), (3, 50, 4)),
-)
+@pytest.mark.parametrize("slicing", ((0,), (5,), (0, 20, 3), (5, 0, 1), (3, 50, 4)))
 async def test_islice_exact(slicing):
     """`isclice` consumes exactly as many items as needed"""
     boundary = slice(*slicing) if len(slicing) > 1 else slice(0, slicing[0])


### PR DESCRIPTION
This PR adds missing features to match the Python3.9 standard library.

* ``functools.cache`` as a shorthand for ``functools.lru_cache(None)``.
* ``functools.lru_cache`` instruments the target with a ``cache_parameters`` function.

See issue #17.