### PR TITLE
Overload annotation for variadic arguments

### DIFF
--- a/asyncstdlib/asynctools.py
+++ b/asyncstdlib/asynctools.py
@@ -8,6 +8,7 @@ from typing import (
     AsyncIterable,
     Callable,
     Any,
+    overload,
 )
 from typing_extensions import AsyncContextManager
 
@@ -17,6 +18,12 @@ from .contextlib import nullcontext
 
 T = TypeVar("T")
 S = TypeVar("S")
+# Variadic overloads
+T1 = TypeVar("T1")
+T2 = TypeVar("T2")
+T3 = TypeVar("T3")
+T4 = TypeVar("T4")
+T5 = TypeVar("T5")
 
 
 class _BorrowedAsyncIterator(AsyncGenerator[T, S]):
@@ -210,6 +217,78 @@ async def await_each(awaitables: Iterable[Awaitable[T]]) -> AsyncIterable[T]:
     """
     for awaitable in awaitables:
         yield await awaitable
+
+
+@overload
+async def apply(
+    __func: Callable[[T1], T],
+    __arg1: Awaitable[T1],
+) -> T:
+    ...
+
+
+@overload
+async def apply(
+    __func: Callable[[T1, T2], T],
+    __arg1: Awaitable[T1],
+    __arg2: Awaitable[T2],
+) -> T:
+    ...
+
+
+@overload
+async def apply(
+    __func: Callable[[T1, T2, T3], T],
+    __arg1: Awaitable[T1],
+    __arg2: Awaitable[T2],
+    __arg3: Awaitable[T3],
+) -> T:
+    ...
+
+
+@overload
+async def apply(
+    __func: Callable[[T1, T2, T3, T4], T],
+    __arg1: Awaitable[T1],
+    __arg2: Awaitable[T2],
+    __arg3: Awaitable[T3],
+    __arg4: Awaitable[T4],
+) -> T:
+    ...
+
+
+@overload
+async def apply(
+    __func: Callable[[T1, T2, T3, T4, T5], T],
+    __arg1: Awaitable[T1],
+    __arg2: Awaitable[T2],
+    __arg3: Awaitable[T3],
+    __arg4: Awaitable[T4],
+    __arg5: Awaitable[T5],
+) -> T:
+    ...
+
+
+@overload
+async def apply(
+    __func: Callable[..., T],
+    __arg1: Awaitable[Any],
+    __arg2: Awaitable[Any],
+    __arg3: Awaitable[Any],
+    __arg4: Awaitable[Any],
+    __arg5: Awaitable[Any],
+    *args: Awaitable[Any],
+    **kwargs: Awaitable[Any],
+) -> T:
+    ...
+
+
+@overload
+async def apply(
+    __func: Callable[..., T],
+    **kwargs: Awaitable[Any],
+) -> T:
+    ...
 
 
 async def apply(

--- a/asyncstdlib/builtins.py
+++ b/asyncstdlib/builtins.py
@@ -141,19 +141,19 @@ async def any(iterable: AnyIterable[T]) -> bool:
 
 
 @overload
-async def zip(__it1: AnyIterable[T1], *, strict=False) -> AsyncIterator[Tuple[T1]]:
+def zip(__it1: AnyIterable[T1], *, strict=False) -> AsyncIterator[Tuple[T1]]:
     ...
 
 
 @overload
-async def zip(
+def zip(
     __it1: AnyIterable[T1], __it2: AnyIterable[T2], *, strict=False
 ) -> AsyncIterator[Tuple[T1, T2]]:
     ...
 
 
 @overload
-async def zip(
+def zip(
     __it1: AnyIterable[T1],
     __it2: AnyIterable[T2],
     __it3: AnyIterable[T3],
@@ -164,7 +164,7 @@ async def zip(
 
 
 @overload
-async def zip(
+def zip(
     __it1: AnyIterable[T1],
     __it2: AnyIterable[T2],
     __it3: AnyIterable[T3],
@@ -176,7 +176,7 @@ async def zip(
 
 
 @overload
-async def zip(
+def zip(
     __it1: AnyIterable[T1],
     __it2: AnyIterable[T2],
     __it3: AnyIterable[T3],
@@ -189,7 +189,7 @@ async def zip(
 
 
 @overload
-async def zip(
+def zip(
     __it1: AnyIterable[Any],
     __it2: AnyIterable[Any],
     __it3: AnyIterable[Any],
@@ -294,19 +294,19 @@ class AsyncVariadic(Protocol[T, R]):
 
 
 @overload
-async def map(
+def map(
     function: Callable[[T1], Awaitable[R]], __it1: AnyIterable[T1]
 ) -> AsyncIterator[R]:
     ...
 
 
 @overload
-async def map(function: Callable[[T1], R], __it1: AnyIterable[T1]) -> AsyncIterator[R]:
+def map(function: Callable[[T1], R], __it1: AnyIterable[T1]) -> AsyncIterator[R]:
     ...
 
 
 @overload
-async def map(
+def map(
     function: Callable[[T1, T2], Awaitable[R]],
     __it1: AnyIterable[T1],
     __it2: AnyIterable[T2],
@@ -315,14 +315,14 @@ async def map(
 
 
 @overload
-async def map(
+def map(
     function: Callable[[T1, T2], R], __it1: AnyIterable[T1], __it2: AnyIterable[T2]
 ) -> AsyncIterator[R]:
     ...
 
 
 @overload
-async def map(
+def map(
     function: Callable[[T1, T2, T3], Awaitable[R]],
     __it1: AnyIterable[T1],
     __it2: AnyIterable[T2],
@@ -332,7 +332,7 @@ async def map(
 
 
 @overload
-async def map(
+def map(
     function: Callable[[T1, T2, T3], R],
     __it1: AnyIterable[T1],
     __it2: AnyIterable[T2],
@@ -342,7 +342,7 @@ async def map(
 
 
 @overload
-async def map(
+def map(
     function: Callable[[T1, T2, T3, T4], Awaitable[R]],
     __it1: AnyIterable[T1],
     __it2: AnyIterable[T2],
@@ -353,7 +353,7 @@ async def map(
 
 
 @overload
-async def map(
+def map(
     function: Callable[[T1, T2, T3, T4], R],
     __it1: AnyIterable[T1],
     __it2: AnyIterable[T2],
@@ -364,7 +364,7 @@ async def map(
 
 
 @overload
-async def map(
+def map(
     function: Callable[[T1, T2, T3, T4, T5], Awaitable[R]],
     __it1: AnyIterable[T1],
     __it2: AnyIterable[T2],
@@ -376,7 +376,7 @@ async def map(
 
 
 @overload
-async def map(
+def map(
     function: Callable[[T1, T2, T3, T4, T5], R],
     __it1: AnyIterable[T1],
     __it2: AnyIterable[T2],
@@ -388,7 +388,7 @@ async def map(
 
 
 @overload
-async def map(
+def map(
     function: Callable[..., Awaitable[R]],
     __it1: AnyIterable[Any],
     __it2: AnyIterable[Any],
@@ -401,7 +401,7 @@ async def map(
 
 
 @overload
-async def map(
+def map(
     function: Callable[..., R],
     __it1: AnyIterable[Any],
     __it2: AnyIterable[Any],
@@ -414,7 +414,7 @@ async def map(
 
 
 async def map(
-    function: Union[SyncVariadic, AsyncVariadic], *iterable: AnyIterable[T]
+    function: Union[SyncVariadic, AsyncVariadic], *iterable: AnyIterable[Any]
 ) -> AsyncIterator[R]:
     r"""
     An async iterator mapping an (async) function to items from (async) iterables

--- a/asyncstdlib/builtins.py
+++ b/asyncstdlib/builtins.py
@@ -279,20 +279,6 @@ async def _zip_inner_strict(aiters):
         return
 
 
-class SyncVariadic(Protocol[T, R]):
-    """Type of a ``def`` function taking any number of arguments"""
-
-    def __call__(self, *args: T) -> R:
-        raise NotImplementedError
-
-
-class AsyncVariadic(Protocol[T, R]):
-    """Type of an ``async def`` function taking any number of arguments"""
-
-    def __call__(self, *args: T) -> Awaitable[R]:
-        raise NotImplementedError
-
-
 @overload
 def map(
     function: Callable[[T1], Awaitable[R]], __it1: AnyIterable[T1]
@@ -414,7 +400,8 @@ def map(
 
 
 async def map(
-    function: Union[SyncVariadic, AsyncVariadic], *iterable: AnyIterable[Any]
+    function: Union[Callable[..., R], Callable[..., Awaitable[R]]],
+    *iterable: AnyIterable[Any],
 ) -> AsyncIterator[R]:
     r"""
     An async iterator mapping an (async) function to items from (async) iterables

--- a/asyncstdlib/builtins.py
+++ b/asyncstdlib/builtins.py
@@ -293,6 +293,126 @@ class AsyncVariadic(Protocol[T, R]):
         raise NotImplementedError
 
 
+@overload
+async def map(
+    function: Callable[[T1], Awaitable[R]], __it1: AnyIterable[T1]
+) -> AsyncIterator[R]:
+    ...
+
+
+@overload
+async def map(function: Callable[[T1], R], __it1: AnyIterable[T1]) -> AsyncIterator[R]:
+    ...
+
+
+@overload
+async def map(
+    function: Callable[[T1, T2], Awaitable[R]],
+    __it1: AnyIterable[T1],
+    __it2: AnyIterable[T2],
+) -> AsyncIterator[R]:
+    ...
+
+
+@overload
+async def map(
+    function: Callable[[T1, T2], R], __it1: AnyIterable[T1], __it2: AnyIterable[T2]
+) -> AsyncIterator[R]:
+    ...
+
+
+@overload
+async def map(
+    function: Callable[[T1, T2, T3], Awaitable[R]],
+    __it1: AnyIterable[T1],
+    __it2: AnyIterable[T2],
+    __it3: AnyIterable[T3],
+) -> AsyncIterator[R]:
+    ...
+
+
+@overload
+async def map(
+    function: Callable[[T1, T2, T3], R],
+    __it1: AnyIterable[T1],
+    __it2: AnyIterable[T2],
+    __it3: AnyIterable[T3],
+) -> AsyncIterator[R]:
+    ...
+
+
+@overload
+async def map(
+    function: Callable[[T1, T2, T3, T4], Awaitable[R]],
+    __it1: AnyIterable[T1],
+    __it2: AnyIterable[T2],
+    __it3: AnyIterable[T3],
+    __it4: AnyIterable[T4],
+) -> AsyncIterator[R]:
+    ...
+
+
+@overload
+async def map(
+    function: Callable[[T1, T2, T3, T4], R],
+    __it1: AnyIterable[T1],
+    __it2: AnyIterable[T2],
+    __it3: AnyIterable[T3],
+    __it4: AnyIterable[T4],
+) -> AsyncIterator[R]:
+    ...
+
+
+@overload
+async def map(
+    function: Callable[[T1, T2, T3, T4, T5], Awaitable[R]],
+    __it1: AnyIterable[T1],
+    __it2: AnyIterable[T2],
+    __it3: AnyIterable[T3],
+    __it4: AnyIterable[T4],
+    __it5: AnyIterable[T5],
+) -> AsyncIterator[R]:
+    ...
+
+
+@overload
+async def map(
+    function: Callable[[T1, T2, T3, T4, T5], R],
+    __it1: AnyIterable[T1],
+    __it2: AnyIterable[T2],
+    __it3: AnyIterable[T3],
+    __it4: AnyIterable[T4],
+    __it5: AnyIterable[T5],
+) -> AsyncIterator[R]:
+    ...
+
+
+@overload
+async def map(
+    function: Callable[..., Awaitable[R]],
+    __it1: AnyIterable[Any],
+    __it2: AnyIterable[Any],
+    __it3: AnyIterable[Any],
+    __it4: AnyIterable[Any],
+    __it5: AnyIterable[Any],
+    *iterable: AnyIterable[Any],
+) -> AsyncIterator[R]:
+    ...
+
+
+@overload
+async def map(
+    function: Callable[..., R],
+    __it1: AnyIterable[Any],
+    __it2: AnyIterable[Any],
+    __it3: AnyIterable[Any],
+    __it4: AnyIterable[Any],
+    __it5: AnyIterable[Any],
+    *iterable: AnyIterable[Any],
+) -> AsyncIterator[R]:
+    ...
+
+
 async def map(
     function: Union[SyncVariadic, AsyncVariadic], *iterable: AnyIterable[T]
 ) -> AsyncIterator[R]:

--- a/asyncstdlib/builtins.py
+++ b/asyncstdlib/builtins.py
@@ -30,6 +30,12 @@ from ._core import (
 T = TypeVar("T", contravariant=True)
 K = TypeVar("K")
 R = TypeVar("R", covariant=True)
+# Variadic overloads
+T1 = TypeVar("T1")
+T2 = TypeVar("T2")
+T3 = TypeVar("T3")
+T4 = TypeVar("T4")
+T5 = TypeVar("T5")
 
 __ANEXT_DEFAULT = Sentinel("<no default>")
 
@@ -134,7 +140,70 @@ async def any(iterable: AnyIterable[T]) -> bool:
         return False
 
 
-async def zip(*iterables: AnyIterable[T], strict=False) -> AsyncIterator[Tuple[T, ...]]:
+@overload
+async def zip(__it1: AnyIterable[T1], *, strict=False) -> AsyncIterator[Tuple[T1]]:
+    ...
+
+
+@overload
+async def zip(
+    __it1: AnyIterable[T1], __it2: AnyIterable[T2], *, strict=False
+) -> AsyncIterator[Tuple[T1, T2]]:
+    ...
+
+
+@overload
+async def zip(
+    __it1: AnyIterable[T1],
+    __it2: AnyIterable[T2],
+    __it3: AnyIterable[T3],
+    *,
+    strict=False,
+) -> AsyncIterator[Tuple[T1, T2, T3]]:
+    ...
+
+
+@overload
+async def zip(
+    __it1: AnyIterable[T1],
+    __it2: AnyIterable[T2],
+    __it3: AnyIterable[T3],
+    __it4: AnyIterable[T4],
+    *,
+    strict=False,
+) -> AsyncIterator[Tuple[T1, T2, T3, T4]]:
+    ...
+
+
+@overload
+async def zip(
+    __it1: AnyIterable[T1],
+    __it2: AnyIterable[T2],
+    __it3: AnyIterable[T3],
+    __it4: AnyIterable[T4],
+    __it5: AnyIterable[T5],
+    *,
+    strict=False,
+) -> AsyncIterator[Tuple[T1, T2, T3, T4, T5]]:
+    ...
+
+
+@overload
+async def zip(
+    __it1: AnyIterable[Any],
+    __it2: AnyIterable[Any],
+    __it3: AnyIterable[Any],
+    __it4: AnyIterable[Any],
+    __it5: AnyIterable[Any],
+    *iterables: AnyIterable[Any],
+    strict=False,
+) -> AsyncIterator[Tuple[Any, ...]]:
+    ...
+
+
+async def zip(
+    *iterables: AnyIterable[Any], strict=False
+) -> AsyncIterator[Tuple[Any, ...]]:
     """
     Create an async iterator that aggregates elements from each of the (async) iterables
 

--- a/asyncstdlib/builtins.py
+++ b/asyncstdlib/builtins.py
@@ -139,13 +139,20 @@ async def any(iterable: AnyIterable[T]) -> bool:
 
 
 @overload
-def zip(__it1: AnyIterable[T1], *, strict=False) -> AsyncIterator[Tuple[T1]]:
+def zip(
+    __it1: AnyIterable[T1],
+    *,
+    strict=False,
+) -> AsyncIterator[Tuple[T1]]:
     ...
 
 
 @overload
 def zip(
-    __it1: AnyIterable[T1], __it2: AnyIterable[T2], *, strict=False
+    __it1: AnyIterable[T1],
+    __it2: AnyIterable[T2],
+    *,
+    strict=False,
 ) -> AsyncIterator[Tuple[T1, T2]]:
     ...
 
@@ -279,13 +286,17 @@ async def _zip_inner_strict(aiters):
 
 @overload
 def map(
-    function: Callable[[T1], Awaitable[R]], __it1: AnyIterable[T1]
+    function: Callable[[T1], Awaitable[R]],
+    __it1: AnyIterable[T1],
 ) -> AsyncIterator[R]:
     ...
 
 
 @overload
-def map(function: Callable[[T1], R], __it1: AnyIterable[T1]) -> AsyncIterator[R]:
+def map(
+    function: Callable[[T1], R],
+    __it1: AnyIterable[T1],
+) -> AsyncIterator[R]:
     ...
 
 

--- a/asyncstdlib/builtins.py
+++ b/asyncstdlib/builtins.py
@@ -16,8 +16,6 @@ from typing import (
 )
 import builtins as _sync_builtins
 
-from typing_extensions import Protocol
-
 from ._core import (
     aiter,
     AnyIterable,

--- a/asyncstdlib/itertools.py
+++ b/asyncstdlib/itertools.py
@@ -393,14 +393,19 @@ async def _repeat(value):
 
 @overload
 def zip_longest(
-    __it1: AnyIterable[T1], *, fillvalue: S = None
+    __it1: AnyIterable[T1],
+    *,
+    fillvalue: S = None,
 ) -> AsyncIterator[Tuple[T1]]:
     ...
 
 
 @overload
 def zip_longest(
-    __it1: AnyIterable[T1], __it2: AnyIterable[T2], *, fillvalue: S = None
+    __it1: AnyIterable[T1],
+    __it2: AnyIterable[T2],
+    *,
+    fillvalue: S = None,
 ) -> AsyncIterator[Tuple[Union[T1, S], Union[T2, S]]]:
     ...
 

--- a/asyncstdlib/itertools.py
+++ b/asyncstdlib/itertools.py
@@ -29,6 +29,12 @@ from .builtins import anext, zip, enumerate as aenumerate, aiter as aiter
 T = TypeVar("T")
 S = TypeVar("S")
 R = TypeVar("R")
+# Variadic overloads
+T1 = TypeVar("T1")
+T2 = TypeVar("T2")
+T3 = TypeVar("T3")
+T4 = TypeVar("T4")
+T5 = TypeVar("T5")
 
 
 async def cycle(iterable: AnyIterable[T]) -> AsyncIterator[T]:
@@ -385,9 +391,74 @@ async def _repeat(value):
         yield value
 
 
+@overload
+def zip_longest(
+    __it1: AnyIterable[T1], *, fillvalue: S = None
+) -> AsyncIterator[Tuple[T1]]:
+    ...
+
+
+@overload
+def zip_longest(
+    __it1: AnyIterable[T1], __it2: AnyIterable[T2], *, fillvalue: S = None
+) -> AsyncIterator[Tuple[Union[T1, S], Union[T2, S]]]:
+    ...
+
+
+@overload
+def zip_longest(
+    __it1: AnyIterable[T1],
+    __it2: AnyIterable[T2],
+    __it3: AnyIterable[T3],
+    *,
+    fillvalue: S = None,
+) -> AsyncIterator[Tuple[Union[T1, S], Union[T2, S], Union[T3, S]]]:
+    ...
+
+
+@overload
+def zip_longest(
+    __it1: AnyIterable[T1],
+    __it2: AnyIterable[T2],
+    __it3: AnyIterable[T3],
+    __it4: AnyIterable[T4],
+    *,
+    fillvalue: S = None,
+) -> AsyncIterator[Tuple[Union[T1, S], Union[T2, S], Union[T3, S], Union[T4, S]]]:
+    ...
+
+
+@overload
+def zip_longest(
+    __it1: AnyIterable[T1],
+    __it2: AnyIterable[T2],
+    __it3: AnyIterable[T3],
+    __it4: AnyIterable[T4],
+    __it5: AnyIterable[T5],
+    *,
+    fillvalue: S = None,
+) -> AsyncIterator[
+    Tuple[Union[T1, S], Union[T2, S], Union[T3, S], Union[T4, S], Union[T5, S]]
+]:
+    ...
+
+
+@overload
+def zip_longest(
+    __it1: AnyIterable[Any],
+    __it2: AnyIterable[Any],
+    __it3: AnyIterable[Any],
+    __it4: AnyIterable[Any],
+    __it5: AnyIterable[Any],
+    *iterables: AnyIterable[Any],
+    fillvalue: S = None,
+) -> AsyncIterator[Tuple[Any, ...]]:
+    ...
+
+
 async def zip_longest(
-    *iterables: AnyIterable[T], fillvalue: S = None
-) -> AsyncIterator[Tuple[Union[T, S], ...]]:
+    *iterables: AnyIterable[Any], fillvalue: S = None
+) -> AsyncIterator[Tuple[Any, ...]]:
     """
     Create an async iterator that aggregates elements from each of the (async) iterables
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -137,3 +137,9 @@ intersphinx_mapping = {
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = True
+
+# -- Sphinx Patches/Fixes ----------------------------------------------------
+
+# disable overload detection – conflicts with manual/steno signatures
+from sphinx.pycode.parser import VariableCommentPicker
+VariableCommentPicker.add_overload_entry = lambda self, *args, **kwargs: ()


### PR DESCRIPTION
This PR adds proper typing to variadic functions:

* [x] ``builtins.zip``
* [x] ``builtins.map``
* [x] ``itertools.zip_longest``
* [x] ``asynctools.apply``

Closes #35.

Also disabled sphinx overload signatures (closes #15).