### PR TITLE
Prepare release 3.9.1

### DIFF
--- a/docs/source/api/asynctools.rst
+++ b/docs/source/api/asynctools.rst
@@ -23,5 +23,9 @@ Iterator lifetime
 .. autofunction:: await_each(awaitables: iter await T)
     :async-for: :T
 
+    .. versionadded:: 3.9.1
+
 .. autofunction:: apply(func: (*T, **T) -> R, *args: await T, **kwargs: await T) -> R
     :async:
+
+    .. versionadded:: 3.9.1

--- a/docs/source/api/asynctools.rst
+++ b/docs/source/api/asynctools.rst
@@ -6,7 +6,7 @@ The asynctools library
     :synopsis: core asynctools variants
 
 The :py:mod:`asyncstdlib.asynctools` library implements the core toolset used by
-:py:mod:`asyncstdlib` itself.
+:py:mod:`asyncstdlib` itself and similar utilities.
 All documented members of this module are separate from internal implementation
 and stable regardless of :py:mod:`asyncstdlib` internals.
 
@@ -19,6 +19,9 @@ Iterator lifetime
 
 .. autofunction:: scoped_iter(iterable: (async) iter T)
     :async-with: :async iter T
+
+Async transforming
+==================
 
 .. autofunction:: await_each(awaitables: iter await T)
     :async-for: :T


### PR DESCRIPTION
Prepare for intermediate release 3.9.1. Cleanup for new features:

- ``asynctools.apply`` (#34) and ``asynctools.await_each`` (#29)
- variadic type hint overloads (#36)

Closes #38.