### PR TITLE
Use typing-extensions only on Python < 3.8

### DIFF
--- a/asyncstdlib/_lrucache.py
+++ b/asyncstdlib/_lrucache.py
@@ -17,8 +17,12 @@ from typing import (
 )
 from functools import update_wrapper
 from collections import OrderedDict
+import sys
 
-from typing_extensions import Protocol, TypedDict
+if sys.version_info[:2] >= (3, 8):
+    from typing import Protocol, TypedDict
+else:
+    from typing_extensions import Protocol, TypedDict
 
 from ._utility import public_module
 

--- a/asyncstdlib/asynctools.py
+++ b/asyncstdlib/asynctools.py
@@ -10,7 +10,12 @@ from typing import (
     Any,
     overload,
 )
-from typing_extensions import AsyncContextManager
+import sys
+
+if sys.version_info[:2] >= (3, 8):
+    from typing import AsyncContextManager
+else:
+    from typing_extensions import AsyncContextManager
 
 from ._core import AnyIterable, aiter
 from .contextlib import nullcontext

--- a/asyncstdlib/contextlib.py
+++ b/asyncstdlib/contextlib.py
@@ -8,11 +8,15 @@ from typing import (
     Any,
     Awaitable,
 )
-from typing_extensions import Protocol, AsyncContextManager, ContextManager
 from functools import wraps
 from collections import deque
 from functools import partial
 import sys
+
+if sys.version_info[:2] >= (3, 8):
+    from typing import Protocol, AsyncContextManager, ContextManager
+else:
+    from typing_extensions import Protocol, AsyncContextManager, ContextManager
 
 from ._core import awaitify
 from ._utility import public_module, slot_get as _slot_get

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3 :: Only",
 ]
-requires = ["typing_extensions"]
+requires = ["typing_extensions; python_version<'3.8'"]
 
 [tool.flit.metadata.requires-extra]
 test = [


### PR DESCRIPTION
All the features used by asyncstdlib are present in stdlib's typing
module in Python 3.8, so use typing-extensions only for older Python
versions.  While technically ContextManager and AsyncContextManager
are also available in older Python versions, we can't eliminate
the typing-extensions dependency entirely for them, so no point
in making the conditions more complex.