### PR TITLE
Maintenance: cached property nesting

### DIFF
--- a/asyncstdlib/functools.py
+++ b/asyncstdlib/functools.py
@@ -117,13 +117,11 @@ class CachedProperty:
 
     async def _get_attribute(self, instance) -> T:
         attributes = instance.__dict__
-        try:
-            return attributes[self._name]
-        except KeyError:
-            value = await self.__wrapped__(instance)
-            if self._name not in attributes:
-                attributes[self._name] = AwaitableValue(value)
-            return value
+        assert self._name not in attributes
+        value = await self.__wrapped__(instance)
+        if self._name not in attributes:
+            attributes[self._name] = AwaitableValue(value)
+        return value
 
 
 cached_property = CachedProperty

--- a/asyncstdlib/functools.py
+++ b/asyncstdlib/functools.py
@@ -116,10 +116,8 @@ class CachedProperty:
         return self._get_attribute(instance)
 
     async def _get_attribute(self, instance) -> T:
-        attributes = instance.__dict__
-        assert self._name not in attributes
         value = await self.__wrapped__(instance)
-        attributes[self._name] = AwaitableValue(value)
+        instance.__dict__[self._name] = AwaitableValue(value)
         return value
 
 

--- a/asyncstdlib/functools.py
+++ b/asyncstdlib/functools.py
@@ -119,8 +119,7 @@ class CachedProperty:
         attributes = instance.__dict__
         assert self._name not in attributes
         value = await self.__wrapped__(instance)
-        if self._name not in attributes:
-            attributes[self._name] = AwaitableValue(value)
+        attributes[self._name] = AwaitableValue(value)
         return value
 
 

--- a/unittests/test_functools.py
+++ b/unittests/test_functools.py
@@ -35,11 +35,11 @@ async def test_cache_property_nodict():
             __slots__ = "a", "b"
 
             def __init__(self, a, b):
-                pass
+                pass  # pragma: no cover
 
             @a.cached_property
             async def total(self):
-                pass
+                pass  # pragma: no cover
 
 
 @multi_sync

--- a/unittests/test_functools.py
+++ b/unittests/test_functools.py
@@ -35,12 +35,11 @@ async def test_cache_property_nodict():
             __slots__ = "a", "b"
 
             def __init__(self, a, b):
-                self.a = a
-                self.b = b
+                pass
 
             @a.cached_property
             async def total(self):
-                return self.a + self.b
+                pass
 
 
 @multi_sync

--- a/unittests/test_functools.py
+++ b/unittests/test_functools.py
@@ -62,7 +62,7 @@ async def test_cache_property_order():
     val = Value(0)
     await Schedule(check_increment(5), check_increment(12), check_increment(1337))
     assert (await val.cached) != 0
-    assert (await val.cached) == 5  # first value fetched
+    assert (await val.cached) == 1337  # last value fetched
 
 
 @sync


### PR DESCRIPTION
This PR cleans up the code of ``cached_property``.

* Removed useless but misleading code path.
* Simplified cache replacement.

Closes #48.