### PR TITLE
Maintenance Cleanup 2021/07

### DIFF
--- a/.github/workflows/verification.yml
+++ b/.github/workflows/verification.yml
@@ -21,3 +21,6 @@ jobs:
     - name: Format with black
       run: |
         black asyncstdlib unittests --diff --check
+    - name: Verify with MyPy
+      run: |
+        mypy

--- a/.github/workflows/verification.yml
+++ b/.github/workflows/verification.yml
@@ -23,4 +23,4 @@ jobs:
         black asyncstdlib unittests --diff --check
     - name: Verify with MyPy
       run: |
-        mypy
+        mypy --pretty

--- a/asyncstdlib/_core.py
+++ b/asyncstdlib/_core.py
@@ -71,9 +71,9 @@ class ScopedIter(Generic[T]):
         self._iterable = None
         return self._iterator
 
-    async def __aexit__(self, exc_type, exc_val, exc_tb):
+    async def __aexit__(self, exc_type, exc_val, exc_tb) -> bool:
         try:
-            aclose = self._iterator.aclose()
+            aclose = self._iterator.aclose()  # type: ignore
         except AttributeError:
             pass
         else:

--- a/asyncstdlib/_core.py
+++ b/asyncstdlib/_core.py
@@ -1,6 +1,5 @@
 from inspect import iscoroutinefunction
 from typing import (
-    TypeVar,
     AsyncIterator,
     Iterable,
     AsyncIterable,
@@ -11,10 +10,7 @@ from typing import (
     Callable,
 )
 
-T = TypeVar("T")
-
-
-AnyIterable = Union[Iterable[T], AsyncIterable[T]]
+from ._typing import T, AnyIterable
 
 
 class Sentinel:

--- a/asyncstdlib/_core.py
+++ b/asyncstdlib/_core.py
@@ -20,6 +20,8 @@ AnyIterable = Union[Iterable[T], AsyncIterable[T]]
 class Sentinel:
     """Placeholder with configurable ``repr``"""
 
+    __slots__ = ("name",)
+
     def __init__(self, name):
         self.name = name
 
@@ -54,6 +56,8 @@ async def _aiter_sync(iterable: Iterable[T]) -> AsyncIterator[T]:
 
 class ScopedIter(Generic[T]):
     """Context manager that provides and cleans up an iterator for an iterable"""
+
+    __slots__ = ("_iterable", "_iterator")
 
     def __init__(self, iterable: AnyIterable[T]):
         self._iterable = iterable

--- a/asyncstdlib/_core.py
+++ b/asyncstdlib/_core.py
@@ -27,9 +27,6 @@ class Sentinel:
         return self.name
 
 
-__ITER_SENTINEL = Sentinel("<no default>")
-
-
 def aiter(subject: AnyIterable[T]) -> AsyncIterator[T]:
     """
     An async iterator object yielding elements from ``subject``

--- a/asyncstdlib/_lrucache.py
+++ b/asyncstdlib/_lrucache.py
@@ -17,13 +17,8 @@ from typing import (
 )
 from functools import update_wrapper
 from collections import OrderedDict
-import sys
 
-if sys.version_info[:2] >= (3, 8):
-    from typing import Protocol, TypedDict
-else:
-    from typing_extensions import Protocol, TypedDict
-
+from ._typing import Protocol, TypedDict
 from ._utility import public_module
 
 

--- a/asyncstdlib/_lrucache.py
+++ b/asyncstdlib/_lrucache.py
@@ -85,7 +85,7 @@ class LRUAsyncCallable(Protocol[R]):
 
 
 @public_module("asyncstdlib.functools")
-def lru_cache(maxsize: Optional[int] = 128, typed: bool = False):
+def lru_cache(maxsize: Optional[Union[int, Callable]] = 128, typed: bool = False):
     """
     Least Recently Used cache for async functions
 
@@ -139,6 +139,7 @@ def lru_cache(maxsize: Optional[int] = 128, typed: bool = False):
         )
 
     def lru_decorator(function: Callable[..., Awaitable[R]]) -> LRUAsyncCallable[R]:
+        assert not callable(maxsize)
         if maxsize is None:
             wrapper = _unbound_lru(function=function, typed=typed)
         elif maxsize == 0:

--- a/asyncstdlib/_lrucache.py
+++ b/asyncstdlib/_lrucache.py
@@ -207,10 +207,10 @@ def _empty_lru(
         nonlocal misses
         misses = 0
 
-    wrapper.cache_parameters = cache_parameters
-    wrapper.cache_info = cache_info
-    wrapper.cache_clear = cache_clear
-    return wrapper
+    wrapper.cache_parameters = cache_parameters  # type: ignore
+    wrapper.cache_info = cache_info  # type: ignore
+    wrapper.cache_clear = cache_clear  # type: ignore
+    return wrapper  # type: ignore
 
 
 def _unbound_lru(
@@ -254,10 +254,10 @@ def _unbound_lru(
         hits = 0
         cache.clear()
 
-    wrapper.cache_parameters = cache_parameters
-    wrapper.cache_info = cache_info
-    wrapper.cache_clear = cache_clear
-    return wrapper
+    wrapper.cache_parameters = cache_parameters  # type: ignore
+    wrapper.cache_info = cache_info  # type: ignore
+    wrapper.cache_clear = cache_clear  # type: ignore
+    return wrapper  # type: ignore
 
 
 def _bounded_lru(
@@ -314,7 +314,7 @@ def _bounded_lru(
         filled = False
         cache.clear()
 
-    wrapper.cache_parameters = cache_parameters
-    wrapper.cache_info = cache_info
-    wrapper.cache_clear = cache_clear
-    return wrapper
+    wrapper.cache_parameters = cache_parameters  # type: ignore
+    wrapper.cache_info = cache_info  # type: ignore
+    wrapper.cache_clear = cache_clear  # type: ignore
+    return wrapper  # type: ignore

--- a/asyncstdlib/_typing.py
+++ b/asyncstdlib/_typing.py
@@ -1,3 +1,9 @@
+"""
+Helper module to simplify version specific typing imports
+
+This module is for internal use only. Do *not* put any new
+"async typing" definitions here.
+"""
 import sys
 
 if sys.version_info[:2] >= (3, 8):
@@ -9,3 +15,5 @@ else:
         ContextManager,
         TypedDict,
     )
+
+__all__ = ["Protocol", "AsyncContextManager", "ContextManager", "TypedDict"]

--- a/asyncstdlib/_typing.py
+++ b/asyncstdlib/_typing.py
@@ -5,7 +5,7 @@ This module is for internal use only. Do *not* put any new
 "async typing" definitions here.
 """
 import sys
-from typing import TypeVar, Hashable
+from typing import TypeVar, Hashable, Union, AsyncIterable, Iterable, Callable
 
 if sys.version_info[:2] >= (3, 8):
     from typing import Protocol, AsyncContextManager, ContextManager, TypedDict
@@ -29,9 +29,11 @@ __all__ = [
     "T4",
     "T5",
     "R",
+    "C",
     "HK",
     "LT",
     "ADD",
+    "AnyIterable",
 ]
 
 # TypeVars for argument/return type
@@ -42,6 +44,7 @@ T3 = TypeVar("T3")
 T4 = TypeVar("T4")
 T5 = TypeVar("T5")
 R = TypeVar("R", covariant=True)
+C = TypeVar("C", bound=Callable)
 
 #: Hashable Key
 HK = TypeVar("HK", bound=Hashable)
@@ -62,3 +65,7 @@ ADD = TypeVar("ADD", bound="SupportsAdd")
 class SupportsAdd(Protocol):
     def __add__(self: ADD, other: ADD) -> bool:
         raise NotImplementedError
+
+
+#: (async) iter T
+AnyIterable = Union[Iterable[T], AsyncIterable[T]]

--- a/asyncstdlib/_typing.py
+++ b/asyncstdlib/_typing.py
@@ -1,0 +1,11 @@
+import sys
+
+if sys.version_info[:2] >= (3, 8):
+    from typing import Protocol, AsyncContextManager, ContextManager, TypedDict
+else:
+    from typing_extensions import (
+        Protocol,
+        AsyncContextManager,
+        ContextManager,
+        TypedDict,
+    )

--- a/asyncstdlib/_typing.py
+++ b/asyncstdlib/_typing.py
@@ -5,6 +5,7 @@ This module is for internal use only. Do *not* put any new
 "async typing" definitions here.
 """
 import sys
+from typing import TypeVar, Hashable
 
 if sys.version_info[:2] >= (3, 8):
     from typing import Protocol, AsyncContextManager, ContextManager, TypedDict
@@ -16,4 +17,48 @@ else:
         TypedDict,
     )
 
-__all__ = ["Protocol", "AsyncContextManager", "ContextManager", "TypedDict"]
+__all__ = [
+    "Protocol",
+    "AsyncContextManager",
+    "ContextManager",
+    "TypedDict",
+    "T",
+    "T1",
+    "T2",
+    "T3",
+    "T4",
+    "T5",
+    "R",
+    "HK",
+    "LT",
+    "ADD",
+]
+
+# TypeVars for argument/return type
+T = TypeVar("T")
+T1 = TypeVar("T1")
+T2 = TypeVar("T2")
+T3 = TypeVar("T3")
+T4 = TypeVar("T4")
+T5 = TypeVar("T5")
+R = TypeVar("R", covariant=True)
+
+#: Hashable Key
+HK = TypeVar("HK", bound=Hashable)
+
+# LT < LT
+LT = TypeVar("LT", bound="SupportsLT")
+
+
+class SupportsLT(Protocol):
+    def __lt__(self: LT, other: LT) -> bool:
+        raise NotImplementedError
+
+
+# ADD + ADD
+ADD = TypeVar("ADD", bound="SupportsAdd")
+
+
+class SupportsAdd(Protocol):
+    def __add__(self: ADD, other: ADD) -> bool:
+        raise NotImplementedError

--- a/asyncstdlib/_utility.py
+++ b/asyncstdlib/_utility.py
@@ -1,12 +1,25 @@
 from typing import TypeVar, Any
 
-T = TypeVar("T")
+from ._typing import Protocol
+
+
+class Definition(Protocol):
+    """
+    Type of objects created from a class or function definition
+    """
+
+    __name__: str
+    __module__: str
+    __qualname__: str
+
+
+D = TypeVar("D", bound=Definition)
 
 
 def public_module(module_name: str, qual_name: str = None):
     """Set the module name of a function or class"""
 
-    def decorator(thing: T) -> T:
+    def decorator(thing: D) -> D:
         thing.__module__ = module_name
         if qual_name is not None:
             thing.__qualname__ = qual_name

--- a/asyncstdlib/_utility.py
+++ b/asyncstdlib/_utility.py
@@ -1,4 +1,4 @@
-from typing import TypeVar, Any
+from typing import TypeVar, Any, Optional
 
 from ._typing import Protocol
 
@@ -16,7 +16,7 @@ class Definition(Protocol):
 D = TypeVar("D", bound=Definition)
 
 
-def public_module(module_name: str, qual_name: str = None):
+def public_module(module_name: str, qual_name: Optional[str] = None):
     """Set the module name of a function or class"""
 
     def decorator(thing: D) -> D:

--- a/asyncstdlib/asynctools.py
+++ b/asyncstdlib/asynctools.py
@@ -11,6 +11,7 @@ from typing import (
     Callable,
     Any,
     overload,
+    Optional,
 )
 
 from ._typing import AsyncContextManager
@@ -33,7 +34,16 @@ class _BorrowedAsyncIterator(AsyncGenerator[T, S]):
     Borrowed async iterator/generator, preventing to ``aclose`` the ``iterable``
     """
 
+    # adding special methods such as `__aiter__` as `__slots__` allows to set them
+    # on the instance: the interpreter expects *descriptors* not methods, and
+    # `__slots__` are descriptors just like methods.
     __slots__ = "__wrapped__", "__aiter__", "__anext__", "asend", "athrow"
+
+    # Type checker does not understand `__slot__` definitions
+    __aiter__: Callable[[], AsyncGenerator[T, S]]
+    __anext__: Callable[[], Awaitable[T]]
+    asend: Any
+    athrow: Any
 
     def __init__(self, iterator: Union[AsyncIterator[T], AsyncGenerator[T, S]]):
         self.__wrapped__ = iterator
@@ -41,21 +51,21 @@ class _BorrowedAsyncIterator(AsyncGenerator[T, S]):
         # We wrap it in a separate async iterator/generator to hide its __aiter__.
         try:
             wrapped_iterator: AsyncGenerator[T, S] = self._wrapped_iterator(iterator)
-            self.__anext__ = iterator.__anext__  # argument must be an async iterable!
+            self.__anext__ = iterator.__anext__  # type: ignore
+            self.__aiter__ = wrapped_iterator.__aiter__  # type: ignore
         except (AttributeError, TypeError):
             raise TypeError(
                 "borrowing requires an async iterator "
                 + f"with __aiter__ and __anext__ method, got {type(iterator).__name__}"
             ) from None
-        self.__aiter__ = wrapped_iterator.__aiter__
-        self.__anext__ = wrapped_iterator.__anext__
+        self.__anext__ = wrapped_iterator.__anext__  # type: ignore
         # Our wrapper cannot pass on asend/athrow without getting much heavier.
         # Since interleaving anext/asend/athrow is not allowed, and the wrapper holds
         # no internal state other than the iterator, circumventing it should be fine.
         if hasattr(iterator, "asend"):
-            self.asend = iterator.asend
+            self.asend = iterator.asend  # type: ignore
         if hasattr(iterator, "athrow"):
-            self.athrow = iterator.athrow
+            self.athrow = iterator.athrow  # type: ignore
 
     # Py3.6 compatibility
     # Use ``(item async for item in iterator)`` inside
@@ -108,7 +118,7 @@ class _ScopedAsyncIteratorContext(AsyncContextManager[AsyncIterator[T]]):
 
     def __init__(self, iterator: AsyncIterator[T]):
         self._iterator: AsyncIterator[T] = iterator
-        self._borrowed_iter = None
+        self._borrowed_iter: Optional[_ScopedAsyncIterator[T, Any]] = None
 
     async def __aenter__(self) -> AsyncIterator[T]:
         if self._borrowed_iter is not None:
@@ -352,11 +362,11 @@ def sync(function: Callable[..., T]) -> Callable[..., Awaitable[T]]:
         if __name__ == "__main__":
             asyncio.run(main())
     """
-    if not isinstance(function, Callable):
+    if not callable(function):
         raise TypeError("function argument should be Callable")
 
     if iscoroutinefunction(function):
-        return function
+        return function  # type: ignore
 
     @wraps(function)
     async def async_wrapped(*args, **kwargs):

--- a/asyncstdlib/asynctools.py
+++ b/asyncstdlib/asynctools.py
@@ -12,13 +12,8 @@ from typing import (
     Any,
     overload,
 )
-import sys
 
-if sys.version_info[:2] >= (3, 8):
-    from typing import AsyncContextManager
-else:
-    from typing_extensions import AsyncContextManager
-
+from ._typing import AsyncContextManager
 from ._core import AnyIterable, aiter
 from .contextlib import nullcontext
 

--- a/asyncstdlib/asynctools.py
+++ b/asyncstdlib/asynctools.py
@@ -14,19 +14,12 @@ from typing import (
     Optional,
 )
 
-from ._typing import AsyncContextManager
-from ._core import AnyIterable, aiter
+from ._typing import AsyncContextManager, T, T1, T2, T3, T4, T5, AnyIterable
+from ._core import aiter
 from .contextlib import nullcontext
 
 
-T = TypeVar("T")
 S = TypeVar("S")
-# Variadic overloads
-T1 = TypeVar("T1")
-T2 = TypeVar("T2")
-T3 = TypeVar("T3")
-T4 = TypeVar("T4")
-T5 = TypeVar("T5")
 
 
 class _BorrowedAsyncIterator(AsyncGenerator[T, S]):

--- a/asyncstdlib/asynctools.py
+++ b/asyncstdlib/asynctools.py
@@ -40,8 +40,8 @@ class _BorrowedAsyncIterator(AsyncGenerator[T, S]):
     __slots__ = "__wrapped__", "__aiter__", "__anext__", "asend", "athrow"
 
     # Type checker does not understand `__slot__` definitions
-    __aiter__: Callable[[], AsyncGenerator[T, S]]
-    __anext__: Callable[[], Awaitable[T]]
+    __aiter__: Callable[[Any], AsyncGenerator[T, S]]
+    __anext__: Callable[[Any], Awaitable[T]]
     asend: Any
     athrow: Any
 
@@ -127,8 +127,8 @@ class _ScopedAsyncIteratorContext(AsyncContextManager[AsyncIterator[T]]):
         return borrowed_iter
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
-        await self._borrowed_iter._aclose_wrapper()
-        await self._iterator.aclose()
+        await self._borrowed_iter._aclose_wrapper()  # type: ignore
+        await self._iterator.aclose()  # type: ignore
         return False
 
     def __repr__(self):

--- a/asyncstdlib/builtins.py
+++ b/asyncstdlib/builtins.py
@@ -3,7 +3,6 @@ from typing import (
     AsyncIterable,
     Union,
     AsyncIterator,
-    TypeVar,
     Awaitable,
     Callable,
     Tuple,
@@ -16,7 +15,7 @@ from typing import (
 )
 import builtins as _sync_builtins
 
-from ._typing import Protocol
+from ._typing import T, T1, T2, T3, T4, T5, R, HK, LT, ADD
 from ._core import (
     aiter,
     AnyIterable,
@@ -24,32 +23,6 @@ from ._core import (
     awaitify as _awaitify,
     Sentinel,
 )
-
-
-T = TypeVar("T")
-K = TypeVar("K")
-R = TypeVar("R", covariant=True)
-# Variadic overloads
-T1 = TypeVar("T1")
-T2 = TypeVar("T2")
-T3 = TypeVar("T3")
-T4 = TypeVar("T4")
-T5 = TypeVar("T5")
-# Basic operations
-LT = TypeVar("LT", bound="SupportsLT")
-
-
-class SupportsLT(Protocol):
-    def __lt__(self: LT, other: LT) -> bool:
-        raise NotImplementedError
-
-
-ADD = TypeVar("ADD", bound="SupportsAdd")
-
-
-class SupportsAdd(Protocol):
-    def __add__(self: ADD, other: ADD) -> bool:
-        raise NotImplementedError
 
 
 __ANEXT_DEFAULT = Sentinel("<no default>")
@@ -628,21 +601,21 @@ async def tuple(iterable: Union[Iterable[T], AsyncIterable[T]] = ()) -> Tuple[T,
 
 @overload
 async def dict(  # noqa: F811
-    iterable: Union[Iterable[Tuple[K, T]], AsyncIterable[Tuple[K, T]]] = (),
-) -> Dict[K, T]:
+    iterable: Union[Iterable[Tuple[HK, T]], AsyncIterable[Tuple[HK, T]]] = (),
+) -> Dict[HK, T]:
     pass
 
 
 @overload  # noqa: F811
 async def dict(  # noqa: F811
-    iterable: Union[Iterable[Tuple[K, T]], AsyncIterable[Tuple[K, T]]] = (),
+    iterable: Union[Iterable[Tuple[HK, T]], AsyncIterable[Tuple[HK, T]]] = (),
     **kwargs: T,
-) -> Dict[Union[K, str], T]:
+) -> Dict[Union[HK, str], T]:
     pass
 
 
 async def dict(  # noqa: F811
-    iterable: Union[Iterable[Tuple[K, T]], AsyncIterable[Tuple[K, T]]] = (),
+    iterable: Union[Iterable[Tuple[HK, T]], AsyncIterable[Tuple[HK, T]]] = (),
     **kwargs: T,
 ) -> Dict[Any, T]:
     """

--- a/asyncstdlib/builtins.py
+++ b/asyncstdlib/builtins.py
@@ -15,10 +15,9 @@ from typing import (
 )
 import builtins as _sync_builtins
 
-from ._typing import T, T1, T2, T3, T4, T5, R, HK, LT, ADD
+from ._typing import T, T1, T2, T3, T4, T5, R, HK, LT, ADD, AnyIterable
 from ._core import (
     aiter,
-    AnyIterable,
     ScopedIter,
     awaitify as _awaitify,
     Sentinel,

--- a/asyncstdlib/builtins.py
+++ b/asyncstdlib/builtins.py
@@ -26,7 +26,7 @@ from ._core import (
 )
 
 
-T = TypeVar("T", contravariant=True)
+T = TypeVar("T")
 K = TypeVar("K")
 R = TypeVar("R", covariant=True)
 # Variadic overloads

--- a/asyncstdlib/builtins.py
+++ b/asyncstdlib/builtins.py
@@ -673,12 +673,26 @@ async def _identity(x: T) -> T:
     return x
 
 
+@overload
 async def sorted(
-    iterable: AnyIterable[LT],
-    *,
-    key: Optional[Callable[[LT], Any]] = None,
-    reverse: bool = False,
+    iterable: AnyIterable[LT], *, key: None = ..., reverse: bool = ...
 ) -> List[LT]:
+    ...
+
+
+@overload
+async def sorted(
+    iterable: AnyIterable[T], *, key: Callable[[T], LT], reverse: bool = ...
+) -> List[T]:
+    ...
+
+
+async def sorted(
+    iterable: AnyIterable[T],
+    *,
+    key: Optional[Callable[[T], Any]] = None,
+    reverse: bool = False,
+) -> List[T]:
     """
     Sort items from an (async) iterable into a new list
 

--- a/asyncstdlib/builtins.py
+++ b/asyncstdlib/builtins.py
@@ -41,7 +41,7 @@ LT = TypeVar("LT", bound="SupportsLT")
 
 class SupportsLT(Protocol):
     def __lt__(self: LT, other: LT) -> bool:
-        ...
+        raise NotImplementedError
 
 
 ADD = TypeVar("ADD", bound="SupportsAdd")
@@ -49,7 +49,7 @@ ADD = TypeVar("ADD", bound="SupportsAdd")
 
 class SupportsAdd(Protocol):
     def __add__(self: ADD, other: ADD) -> bool:
-        ...
+        raise NotImplementedError
 
 
 __ANEXT_DEFAULT = Sentinel("<no default>")

--- a/asyncstdlib/contextlib.py
+++ b/asyncstdlib/contextlib.py
@@ -15,7 +15,7 @@ from collections import deque
 from functools import partial
 import sys
 
-from ._typing import Protocol, AsyncContextManager, ContextManager
+from ._typing import Protocol, AsyncContextManager, ContextManager, T
 from ._core import awaitify
 from ._utility import public_module, slot_get as _slot_get
 
@@ -30,7 +30,6 @@ class ACloseable(Protocol):
         """Asynchronously close this object"""
 
 
-T = TypeVar("T")
 AC = TypeVar("AC", bound=ACloseable)
 
 

--- a/asyncstdlib/contextlib.py
+++ b/asyncstdlib/contextlib.py
@@ -13,11 +13,7 @@ from collections import deque
 from functools import partial
 import sys
 
-if sys.version_info[:2] >= (3, 8):
-    from typing import Protocol, AsyncContextManager, ContextManager
-else:
-    from typing_extensions import Protocol, AsyncContextManager, ContextManager
-
+from ._typing import Protocol, AsyncContextManager, ContextManager
 from ._core import awaitify
 from ._utility import public_module, slot_get as _slot_get
 

--- a/asyncstdlib/functools.py
+++ b/asyncstdlib/functools.py
@@ -1,7 +1,8 @@
-from typing import Callable, TypeVar, Awaitable, Union, Any
+from typing import Callable, Awaitable, Union, Any
 
+from ._typing import T, C, AnyIterable
 from ._core import ScopedIter, awaitify as _awaitify, Sentinel
-from .builtins import anext, AnyIterable
+from .builtins import anext
 from ._utility import public_module
 
 from ._lrucache import lru_cache, CacheInfo, CacheParameters, LRUAsyncCallable
@@ -17,11 +18,7 @@ __all__ = [
 ]
 
 
-T = TypeVar("T")
-R = TypeVar("R")
-
-
-def cache(user_function: Callable[..., Awaitable[R]]) -> LRUAsyncCallable[R]:
+def cache(user_function: C) -> LRUAsyncCallable[C]:
     """
     Simple unbounded cache, aka memoization,  for async functions
 

--- a/asyncstdlib/functools.py
+++ b/asyncstdlib/functools.py
@@ -127,7 +127,7 @@ cached_property = CachedProperty
 async def reduce(
     function: Union[Callable[[T, T], T], Callable[[T, T], Awaitable[T]]],
     iterable: AnyIterable[T],
-    initial: T = __REDUCE_SENTINEL,
+    initial: T = __REDUCE_SENTINEL,  # type: ignore
 ) -> T:
     """
     Reduce an (async) iterable by cumulative application of an (async) function
@@ -153,4 +153,4 @@ async def reduce(
         function = _awaitify(function)
         async for head in item_iter:
             value = await function(value, head)
-        return value
+    return value

--- a/asyncstdlib/functools.py
+++ b/asyncstdlib/functools.py
@@ -45,7 +45,7 @@ class AwaitableValue:
     # noinspection PyUnreachableCode
     def __await__(self):
         return self.value
-        yield  # pragma: no cover
+        yield  # type: ignore # pragma: no cover
 
     def __repr__(self):
         return f"{self.__class__.__name__}({self.value!r})"

--- a/asyncstdlib/itertools.py
+++ b/asyncstdlib/itertools.py
@@ -272,6 +272,7 @@ async def takewhile(
 async def tee_peer(
     iterator: AsyncIterator[T], buffer: Deque[T], peers: List[Deque[T]],
 ) -> AsyncGenerator[T, None]:
+    """An individual iterator of a :py:func:`~.tee`"""
     try:
         while True:
             if not buffer:
@@ -285,8 +286,8 @@ async def tee_peer(
                     # This ensures the proper item ordering if any of our peers
                     # are fetching items concurrently. They may have buffered their
                     # item already.
-                    for peer in peers:
-                        peer.append(item)
+                    for peer_buffer in peers:
+                        peer_buffer.append(item)
             yield buffer.popleft()
     finally:
         # this peer is done – remove its buffer

--- a/asyncstdlib/itertools.py
+++ b/asyncstdlib/itertools.py
@@ -337,7 +337,7 @@ class Tee(Generic[T]):
 
     def __init__(self, iterable: AnyIterable[T], n: int = 2):
         self._iterator = aiter(iterable)
-        _cleanup = self._iterator is iterable
+        _cleanup = True
         self._buffers: List[Deque[T]] = [deque() for _ in range(n)]
         self._children = tuple(
             tee_peer(

--- a/asyncstdlib/itertools.py
+++ b/asyncstdlib/itertools.py
@@ -184,7 +184,7 @@ async def dropwhile(
     async with ScopedIter(iterable) as async_iter:
         predicate = _awaitify(predicate)
         async for item in async_iter:
-            if not await predicate(item):  # type: ignore
+            if not await predicate(item):
                 yield item
                 break
         async for item in async_iter:
@@ -397,7 +397,7 @@ async def _repeat(value):
 def zip_longest(
     __it1: AnyIterable[T1],
     *,
-    fillvalue: S = None,
+    fillvalue: S = ...,
 ) -> AsyncIterator[Tuple[T1]]:
     ...
 
@@ -407,7 +407,7 @@ def zip_longest(
     __it1: AnyIterable[T1],
     __it2: AnyIterable[T2],
     *,
-    fillvalue: S = None,
+    fillvalue: S = ...,
 ) -> AsyncIterator[Tuple[Union[T1, S], Union[T2, S]]]:
     ...
 
@@ -418,7 +418,7 @@ def zip_longest(
     __it2: AnyIterable[T2],
     __it3: AnyIterable[T3],
     *,
-    fillvalue: S = None,
+    fillvalue: S = ...,
 ) -> AsyncIterator[Tuple[Union[T1, S], Union[T2, S], Union[T3, S]]]:
     ...
 
@@ -430,7 +430,7 @@ def zip_longest(
     __it3: AnyIterable[T3],
     __it4: AnyIterable[T4],
     *,
-    fillvalue: S = None,
+    fillvalue: S = ...,
 ) -> AsyncIterator[Tuple[Union[T1, S], Union[T2, S], Union[T3, S], Union[T4, S]]]:
     ...
 
@@ -443,7 +443,7 @@ def zip_longest(
     __it4: AnyIterable[T4],
     __it5: AnyIterable[T5],
     *,
-    fillvalue: S = None,
+    fillvalue: S = ...,
 ) -> AsyncIterator[
     Tuple[Union[T1, S], Union[T2, S], Union[T3, S], Union[T4, S], Union[T5, S]]
 ]:
@@ -458,13 +458,13 @@ def zip_longest(
     __it4: AnyIterable[Any],
     __it5: AnyIterable[Any],
     *iterables: AnyIterable[Any],
-    fillvalue: S = None,
+    fillvalue: S = ...,
 ) -> AsyncIterator[Tuple[Any, ...]]:
     ...
 
 
 async def zip_longest(
-    *iterables: AnyIterable[Any], fillvalue: S = None
+    *iterables: AnyIterable[Any], fillvalue: Any = None
 ) -> AsyncIterator[Tuple[Any, ...]]:
     """
     Create an async iterator that aggregates elements from each of the (async) iterables

--- a/asyncstdlib/itertools.py
+++ b/asyncstdlib/itertools.py
@@ -16,25 +16,17 @@ from typing import (
 )
 from collections import deque
 
+from ._typing import T, R, T1, T2, T3, T4, T5, AnyIterable
 from ._utility import public_module
 from ._core import (
     ScopedIter,
-    AnyIterable,
     awaitify as _awaitify,
     Sentinel,
     borrow as _borrow,
 )
 from .builtins import anext, zip, enumerate as aenumerate, aiter as aiter
 
-T = TypeVar("T")
 S = TypeVar("S")
-R = TypeVar("R")
-# Variadic overloads
-T1 = TypeVar("T1")
-T2 = TypeVar("T2")
-T3 = TypeVar("T3")
-T4 = TypeVar("T4")
-T5 = TypeVar("T5")
 
 
 async def cycle(iterable: AnyIterable[T]) -> AsyncIterator[T]:

--- a/asyncstdlib/itertools.py
+++ b/asyncstdlib/itertools.py
@@ -270,7 +270,9 @@ async def takewhile(
 
 
 async def tee_peer(
-    iterator: AsyncIterator[T], buffer: Deque[T], peers: List[Deque[T]],
+    iterator: AsyncIterator[T],
+    buffer: Deque[T],
+    peers: List[Deque[T]],
 ) -> AsyncGenerator[T, None]:
     """An individual iterator of a :py:func:`~.tee`"""
     try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3 :: Only",
 ]
+requires-python = "~=3.6"
 requires = ["typing_extensions; python_version<'3.8'"]
 
 [tool.flit.metadata.requires-extra]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,3 +39,4 @@ check_untyped_defs = true
 no_implicit_optional = true
 warn_redundant_casts = true
 warn_unused_ignores = true
+warn_unreachable = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ test = [
     "black; implementation_name=='cpython'",
     "coverage",
     "pytest-cov",
-    "mypy",
+    "mypy; implementation_name=='cpython'",
 ]
 doc = ["sphinx", "sphinxcontrib-contentui", "sphinxcontrib-trio"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,3 +31,8 @@ doc = ["sphinx", "sphinxcontrib-contentui", "sphinxcontrib-trio"]
 
 [tool.flit.metadata.urls]
 Documentation = "https://asyncstdlib.readthedocs.io/en/latest/"
+
+[tool.mypy]
+files = ["asyncstdlib/*.py"]
+check_untyped_defs = true
+no_implicit_optional = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,3 +36,5 @@ Documentation = "https://asyncstdlib.readthedocs.io/en/latest/"
 files = ["asyncstdlib/*.py"]
 check_untyped_defs = true
 no_implicit_optional = true
+warn_redundant_casts = true
+warn_unused_ignores = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ test = [
     "black; implementation_name=='cpython'",
     "coverage",
     "pytest-cov",
+    "mypy",
 ]
 doc = ["sphinx", "sphinxcontrib-contentui", "sphinxcontrib-trio"]
 

--- a/unittests/utility.py
+++ b/unittests/utility.py
@@ -57,7 +57,7 @@ def sync(test_case: Callable[..., Coroutine]):
             event = None
             while True:
                 event = coro.send(event)
-                if not isinstance(event, PingPong):
+                if not isinstance(event, PingPong):  # pragma: no cover
                     raise RuntimeError(
                         f"test case {test_case} yielded an unexpected event {event}"
                     )
@@ -112,7 +112,7 @@ def multi_sync(test_case: Callable[..., Coroutine]):
                     run_queue.append((coro, event))
                 elif isinstance(event, Switch):
                     run_queue.append((coro, event))
-                else:
+                else:  # pragma: no cover
                     raise RuntimeError(
                         f"test case {test_case} yielded an unexpected event {event}"
                     )


### PR DESCRIPTION
This PR includes general cleanup of the package.

* [x] Cleanup of ``typing`` imports
* [x] Merging of ``typing`` declarations?
* [x] Metadata for type annotations
* [x] Type soundness?
* [x] ``itertools.tee`` custom ``cleanup`` logic – remove it?
* [x] ...

Closes #40.

--------------

Missing ``@overload``:
* [ ] ``max``
* [ ] ``max``
* [x] ``sorted``
