### PR TITLE
Release 3.10.1: Fixed type checking support

### DIFF
--- a/asyncstdlib/__init__.py
+++ b/asyncstdlib/__init__.py
@@ -35,7 +35,7 @@ from .itertools import (
 )
 from .asynctools import borrow, scoped_iter, await_each, apply, sync
 
-__version__ = "3.10.0"
+__version__ = "3.10.1"
 
 __all__ = [
     "anext",

--- a/asyncstdlib/builtins.py
+++ b/asyncstdlib/builtins.py
@@ -262,7 +262,7 @@ async def _zip_inner_strict(aiters):
             plural = " " if tried == 1 else "s 1-"
             raise ValueError(
                 f"zip() argument {tried+1} is shorter than argument{plural}{tried}"
-            )
+            ) from None
         # after the first iterable was empty, some later iterable may be not
         sentinel = object()
         for tried, _aiter in _sync_builtins.enumerate(aiters):
@@ -270,7 +270,7 @@ async def _zip_inner_strict(aiters):
                 plural = " " if tried == 1 else "s 1-"
                 raise ValueError(
                     f"zip() argument {tried+1} is longer than argument{plural}{tried}"
-                )
+                ) from None
         return
 
 

--- a/asyncstdlib/functools.py
+++ b/asyncstdlib/functools.py
@@ -146,7 +146,9 @@ async def reduce(
                 initial if initial is not __REDUCE_SENTINEL else await anext(item_iter)
             )
         except StopAsyncIteration:
-            raise TypeError("reduce() of empty sequence with no initial value")
+            raise TypeError(
+                "reduce() of empty sequence with no initial value"
+            ) from None
         function = _awaitify(function)
         async for head in item_iter:
             value = await function(value, head)

--- a/asyncstdlib/itertools.py
+++ b/asyncstdlib/itertools.py
@@ -99,8 +99,10 @@ async def accumulate(
                 if initial is not __ACCUMULATE_SENTINEL
                 else await anext(item_iter)
             )
-        except StopAsyncIteration:
-            raise TypeError("accumulate() of empty sequence with no initial value")
+        except StopAsyncIteration as err:
+            raise TypeError(
+                "accumulate() of empty sequence with no initial value"
+            ) from None
         function = _awaitify(function)
         yield value
         async for head in item_iter:

--- a/asyncstdlib/itertools.py
+++ b/asyncstdlib/itertools.py
@@ -99,7 +99,7 @@ async def accumulate(
                 if initial is not __ACCUMULATE_SENTINEL
                 else await anext(item_iter)
             )
-        except StopAsyncIteration as err:
+        except StopAsyncIteration:
             raise TypeError(
                 "accumulate() of empty sequence with no initial value"
             ) from None

--- a/unittests/test_contextlib.py
+++ b/unittests/test_contextlib.py
@@ -82,7 +82,7 @@ async def test_contextmanager_raise_asyncstop():
         try:
             yield
         except StopAsyncIteration:
-            raise StopAsyncIteration("inside")
+            raise StopAsyncIteration("inside") from None
 
     with pytest.raises(RuntimeError):
         async with replace():
@@ -104,7 +104,7 @@ async def test_contextmanager_raise_runtimeerror():
         try:
             yield
         except RuntimeError:
-            raise RuntimeError("inside")
+            raise RuntimeError("inside") from None
 
     with pytest.raises(RuntimeError, match="inside"):
         async with replace():
@@ -129,7 +129,7 @@ async def test_contextmanager_raise_same():
         try:
             yield
         except BaseException as err:
-            raise type(err)("inside")
+            raise type(err)("inside") from None
 
     with pytest.raises(KeyError, match="inside"):
         async with recreate():


### PR DESCRIPTION
This PR fixes type checking support when using ``asyncstdlib`` with other libraries.

* [x] moved ``py.typed`` marker as required by [PEP 561](https://www.python.org/dev/peps/pep-0561/)
* [x] current linter best practices
* [ ] version bump

Closes #61.