### PR TITLE
Fix `async` prefix for `groupby` type annotation overloads.

### DIFF
--- a/asyncstdlib/itertools.py
+++ b/asyncstdlib/itertools.py
@@ -512,21 +512,21 @@ async def identity(x: T) -> T:
 
 
 @overload  # noqa: F811
-async def groupby(  # noqa: F811
+def groupby(  # noqa: F811
     iterable: AnyIterable[T],
 ) -> AsyncIterator[Tuple[T, AsyncIterator[T]]]:
     ...
 
 
 @overload  # noqa: F811
-async def groupby(  # noqa: F811
+def groupby(  # noqa: F811
     iterable: AnyIterable[T], key: None
 ) -> AsyncIterator[Tuple[T, AsyncIterator[T]]]:
     ...
 
 
 @overload  # noqa: F811
-async def groupby(  # noqa: F811
+def groupby(  # noqa: F811
     iterable: AnyIterable[T], key: Union[Callable[[T], R], Callable[[T], Awaitable[R]]]
 ) -> AsyncIterator[Tuple[R, AsyncIterator[T]]]:
     ...


### PR DESCRIPTION
The overload stubs for `groupby` are not generator functions, so mypy currently infers that they return an awaitable that yields an `AsyncIterator` rather than that they return an `AsyncIterator` directly.  All other similar overloads have correct annotations.
