### PR TITLE
Add heapq module

### DIFF
--- a/asyncstdlib/__init__.py
+++ b/asyncstdlib/__init__.py
@@ -34,6 +34,7 @@ from .itertools import (
     groupby,
 )
 from .asynctools import borrow, scoped_iter, await_each, apply, sync
+from .heapq import merge
 
 __version__ = "3.10.2"
 
@@ -83,4 +84,6 @@ __all__ = [
     "await_each",
     "apply",
     "sync",
+    # heapq
+    "merge",
 ]

--- a/asyncstdlib/__init__.py
+++ b/asyncstdlib/__init__.py
@@ -34,7 +34,7 @@ from .itertools import (
     groupby,
 )
 from .asynctools import borrow, scoped_iter, await_each, apply, sync
-from .heapq import merge
+from .heapq import merge, nlargest, nsmallest
 
 __version__ = "3.10.2"
 
@@ -86,4 +86,6 @@ __all__ = [
     "sync",
     # heapq
     "merge",
+    "nlargest",
+    "nsmallest",
 ]

--- a/asyncstdlib/heapq.py
+++ b/asyncstdlib/heapq.py
@@ -173,12 +173,8 @@ async def merge(
                 yield item
     finally:
         for itr, _ in iter_heap:
-            try:
-                aclose = itr.tail.aclose  # type: ignore
-            except AttributeError:
-                pass
-            else:
-                await aclose()
+            if hasattr(itr.tail, "aclose"):
+                await itr.tail.aclose()
 
 
 class ReverseLT(Generic[LT]):

--- a/asyncstdlib/heapq.py
+++ b/asyncstdlib/heapq.py
@@ -86,7 +86,7 @@ class _KeyIter(Generic[LT]):
 
     async def pull_head(self) -> bool:
         """
-        Pulling the next ``head`` element from the iterator and signal success
+        Pull the next ``head`` element from the iterator and signal success
         """
         try:
             self.head = head = await self.tail.__anext__()

--- a/asyncstdlib/heapq.py
+++ b/asyncstdlib/heapq.py
@@ -203,7 +203,9 @@ async def _largest(
     key: Callable[[T], Awaitable[LT]],
     reverse: bool,
 ) -> list[T]:
-    ordered: Callable[[SupportsLT], SupportsLT] = ReverseLT if reverse else lambda x: x  # type: ignore
+    ordered: Callable[[SupportsLT], SupportsLT] = (
+        ReverseLT if reverse else lambda x: x  # type: ignore
+    )
     async with ScopedIter(iterable) as iterator:
         # assign an ordering to items to solve ties
         order_sign = -1 if reverse else 1
@@ -246,7 +248,9 @@ async def nlargest(
     The result is equivalent to ``sorted(iterable, key=key, reverse=True)[:n]``,
     but ``iterable`` is consumed lazily and items are discarded eagerly.
     """
-    a_key: Callable[[Any], Awaitable[Any]] = awaitify(key) if key is not None else _identity  # type: ignore
+    a_key: Callable[[Any], Awaitable[Any]] = (
+        awaitify(key) if key is not None else _identity  # type: ignore
+    )
     return await _largest(iterable=iterable, n=n, key=a_key, reverse=False)
 
 
@@ -260,5 +264,7 @@ async def nsmallest(
 
     Provides the reverse functionality to :py:func:`~.nlargest`.
     """
-    a_key: Callable[[Any], Awaitable[Any]] = awaitify(key) if key is not None else _identity  # type: ignore
+    a_key: Callable[[Any], Awaitable[Any]] = (
+        awaitify(key) if key is not None else _identity  # type: ignore
+    )
     return await _largest(iterable=iterable, n=n, key=a_key, reverse=True)

--- a/asyncstdlib/heapq.py
+++ b/asyncstdlib/heapq.py
@@ -174,7 +174,7 @@ async def merge(
     finally:
         for itr, _ in iter_heap:
             if hasattr(itr.tail, "aclose"):
-                await itr.tail.aclose()
+                await itr.tail.aclose()  # type: ignore
 
 
 class ReverseLT(Generic[LT]):

--- a/asyncstdlib/heapq.py
+++ b/asyncstdlib/heapq.py
@@ -1,0 +1,96 @@
+from typing import Generic, AsyncIterator, Tuple, List
+import heapq as _heapq
+
+from .builtins import aiter, enumerate as a_enumerate
+from ._typing import AnyIterable, LT
+
+
+class _KeyIter(Generic[LT]):
+    __slots__ = ("head", "tail", "reverse", "head_key", "key")
+
+    def __init__(self, head: LT, tail: AsyncIterator[LT], reverse: bool, head_key, key):
+        self.head = head
+        self.head_key = head_key
+        self.tail = tail
+        self.key = key
+        self.reverse = reverse
+
+    @classmethod
+    async def from_iters(
+        cls, iterables: Tuple[AnyIterable[LT]], reverse: bool, key
+    ) -> "AsyncIterator[_KeyIter[LT]]":
+        for iterable in iterables:
+            iterator = aiter(iterable)
+            try:
+                head = await iterator.__anext__()
+            except StopAsyncIteration:
+                pass
+            else:
+                yield cls(head, iterator, reverse, await key(head), key)
+
+    async def pull_head(self) -> bool:
+        """
+        Pulling the next ``head`` element from the iterator and signal success
+        """
+        try:
+            self.head = head = await self.tail.__anext__()
+        except StopAsyncIteration:
+            return False
+        else:
+            self.head_key = self.key(head) if self.key is not None else head
+            return True
+
+    def __lt__(self, other: "_KeyIter[LT]"):
+        return self.reverse ^ (self.head_key < other.head_key)
+
+
+async def merge(
+    *iterables: AnyIterable[LT], key=None, reverse: bool = False
+) -> AsyncIterator[LT]:
+    """
+    Merge all pre-sorted (async) ``iterables`` into a single sorted iterator
+
+    This works similar to ``sorted(chain(*iterables), key=key, reverse=reverse)`` but
+    operates lazily: at any moment only one item of each iterable is stored for the
+    comparison. This allows merging streams of pre-sorted items, such as timestamped
+    records from multiple sources.
+
+    The optional ``key`` argument specifies a one-argument (async) callable, which
+    provides a substitute for determining the sort order of each item.
+    The special value and default :py:data:`None` represents the identity functions,
+    comparing items directly.
+
+    The default sort order is ascending, that is items with ``a < b`` imply ``a``
+    is yielded before ``b``. Use ``reverse=True`` for descending sort order.
+    The ``iterables`` must be pre-sorted in the same order.
+    """
+    iter_heap: List[Tuple[_KeyIter, int]] = [
+        (itr, idx if not reverse else -idx)
+        async for idx, itr
+        in a_enumerate(_KeyIter.from_iters(iterables, reverse, key))
+    ]
+    try:
+        _heapq.heapify(iter_heap)
+        # there are at least two iterators that need merging
+        while len(iter_heap) > 1:
+            while True:
+                itr, idx = iter_heap[0]
+                yield itr.head
+                if await itr.pull_head():
+                    _heapq.heapreplace(iter_heap, (itr, idx))
+                else:
+                    _heapq.heappop(iter_heap)
+        # there is only one iterator left, no need for merging
+        if iter_heap:
+            itr, idx = iter_heap[0]
+            yield itr.head
+            async for item in itr.tail:
+                yield item
+    finally:
+        for itr, _ in iter_heap:
+            try:
+                aclose = itr.tail.aclose  # type: ignore
+            except AttributeError:
+                pass
+            else:
+                await aclose()

--- a/asyncstdlib/heapq.py
+++ b/asyncstdlib/heapq.py
@@ -198,7 +198,7 @@ async def _largest(
     n: int,
     key: Callable[[T], Awaitable[LT]],
     reverse: bool,
-) -> list[T]:
+) -> List[T]:
     ordered: Callable[[SupportsLT], SupportsLT] = (
         ReverseLT if reverse else lambda x: x  # type: ignore
     )
@@ -232,7 +232,7 @@ async def nlargest(
     iterable: AsyncIterator[T],
     n: int,
     key: Optional[Callable[[Any], Awaitable[Any]]] = None,
-) -> list[T]:
+) -> List[T]:
     """
     Return a sorted list of the ``n`` largest elements from the (async) iterable
 
@@ -254,7 +254,7 @@ async def nsmallest(
     iterable: AsyncIterator[T],
     n: int,
     key: Optional[Callable[[Any], Awaitable[Any]]] = None,
-) -> list[T]:
+) -> List[T]:
     """
     Return a sorted list of the ``n`` smallest elements from the (async) iterable
 

--- a/asyncstdlib/heapq.py
+++ b/asyncstdlib/heapq.py
@@ -11,9 +11,9 @@ from typing import (
 )
 import heapq as _heapq
 
-from .builtins import enumerate as a_enumerate
-from ._core import aiter, awaitify
-from ._typing import AnyIterable, LT, T
+from .builtins import enumerate as a_enumerate, zip as a_zip
+from ._core import aiter, awaitify, ScopedIter, borrow
+from ._typing import AnyIterable, LT, T, SupportsLT
 
 
 class _KeyIter(Generic[LT]):
@@ -179,3 +179,87 @@ async def merge(
                 pass
             else:
                 await aclose()
+
+
+class ReverseLT(Generic[LT]):
+    """Helper to reverse ``a < b`` ordering"""
+
+    __slots__ = ("key",)
+
+    def __init__(self, key: LT):
+        self.key = key
+
+    def __lt__(self, other: "ReverseLT[LT]") -> bool:
+        return other.key < self.key
+
+
+# Python's heapq provides a *min*-heap
+# When finding the n largest items, heapq tracks the *minimum* item still large enough.
+# In other words, during search we maintain opposite sort order than what is requested.
+# We turn the min-heap into a max-sort in the end.
+async def _largest(
+    iterable: AsyncIterator[T],
+    n: int,
+    key: Callable[[T], Awaitable[LT]],
+    reverse: bool,
+) -> list[T]:
+    ordered: Callable[[SupportsLT], SupportsLT] = ReverseLT if reverse else lambda x: x  # type: ignore
+    async with ScopedIter(iterable) as iterator:
+        # assign an ordering to items to solve ties
+        order_sign = -1 if reverse else 1
+        n_heap = [
+            (ordered(await key(item)), index * order_sign, item)
+            async for index, item
+            in a_zip(range(n), borrow(iterator))
+        ]
+        if not n_heap:
+            return []
+        _heapq.heapify(n_heap)
+        worst_key = n_heap[0][0]
+        next_index = n * order_sign
+        async for item in iterator:
+            item_key = ordered(await key(item))
+            if worst_key < item_key:
+                _heapq.heapreplace(n_heap, (item_key, next_index, item))
+                worst_key = n_heap[0][0]
+                next_index += 1 * order_sign
+        n_heap.sort(reverse=True)
+    return [item for _, _, item in n_heap]
+
+
+async def _identity(x: T) -> T:
+    return x
+
+
+async def nlargest(
+    iterable: AsyncIterator[T],
+    n: int,
+    key: Optional[Callable[[Any], Awaitable[Any]]] = None,
+) -> list[T]:
+    """
+    Return a sorted list of the ``n`` largest elements from the (async) iterable
+
+    The optional ``key`` argument specifies a one-argument (async) callable, which
+    provides a substitute for determining the sort order of each item.
+    The special value and default :py:data:`None` represents the identity functions,
+    comparing items directly.
+
+    The result is equivalent to ``sorted(iterable, key=key, reverse=True)[:n]``,
+    but ``iterable`` is consumed lazily and items are discarded eagerly.
+    """
+    a_key: Callable[[Any], Awaitable[Any]] = awaitify(key) if key is not None else _identity  # type: ignore
+    return await _largest(iterable=iterable, n=n, key=a_key, reverse=False)
+
+
+async def nsmallest(
+    iterable: AsyncIterator[T],
+    n: int,
+    key: Optional[Callable[[Any], Awaitable[Any]]] = None,
+) -> list[T]:
+    """
+    Return a sorted list of the ``n`` smallest elements from the (async) iterable
+
+    Provides the reverse functionality to :py:func:`~.nlargest`.
+    """
+    a_key: Callable[[Any], Awaitable[Any]] = awaitify(key) if key is not None else _identity  # type: ignore
+    return await _largest(iterable=iterable, n=n, key=a_key, reverse=True)

--- a/asyncstdlib/heapq.py
+++ b/asyncstdlib/heapq.py
@@ -209,8 +209,7 @@ async def _largest(
         order_sign = -1 if reverse else 1
         n_heap = [
             (ordered(await key(item)), index * order_sign, item)
-            async for index, item
-            in a_zip(range(n), borrow(iterator))
+            async for index, item in a_zip(range(n), borrow(iterator))
         ]
         if not n_heap:
             return []

--- a/asyncstdlib/heapq.py
+++ b/asyncstdlib/heapq.py
@@ -138,7 +138,7 @@ async def merge(
 
     The optional ``key`` argument specifies a one-argument (async) callable, which
     provides a substitute for determining the sort order of each item.
-    The special value and default :py:data:`None` represents the identity functions,
+    The special value and default :py:data:`None` represents the identity function,
     comparing items directly.
 
     The default sort order is ascending, that is items with ``a < b`` imply ``a``

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -31,7 +31,7 @@ The missing ``async`` toolbox
     :synopsis: The async standard library
 
 .. toctree::
-   :maxdepth: 1
+   :maxdepth: 2
    :caption: The Async Toolbox
    :hidden:
 
@@ -43,7 +43,7 @@ The missing ``async`` toolbox
    source/api/asynctools
 
 .. toctree::
-   :maxdepth: 1
+   :maxdepth: 2
    :caption: Guides and Notes
    :hidden:
 
@@ -51,7 +51,7 @@ The missing ``async`` toolbox
    source/glossary
 
 .. toctree::
-   :maxdepth: 1
+   :maxdepth: 2
    :caption: Development & Maintenance
    :hidden:
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -39,6 +39,7 @@ The missing ``async`` toolbox
    source/api/functools
    source/api/contextlib
    source/api/itertools
+   source/api/heapq
    source/api/asynctools
 
 .. toctree::
@@ -92,6 +93,12 @@ with the same name as those of the Python standard library.
     such as :py:func:`~asyncstdlib.itertools.cycle`,
     :py:func:`~asyncstdlib.itertools.chain`,
     or :py:func:`~asyncstdlib.itertools.accumulate`.
+
+:py:mod:`asyncstdlib.heapq`
+    Replicates any :py:mod:`heapq` tools that benefit from being asynchronous,
+    which is just :py:func:`~asyncstdlib.heapq.merge`,
+    :py:func:`~asyncstdlib.heapq.nlargest`, and
+    :py:func:`~asyncstdlib.heapq.nsmallest`.
 
 For simplicity, the :py:mod:`asyncstdlib` namespace also exposes all individual
 functions and classes directly.

--- a/docs/source/api/heapq.rst
+++ b/docs/source/api/heapq.rst
@@ -1,0 +1,33 @@
+=================
+The heapq library
+=================
+
+.. py:module:: asyncstdlib.heapq
+    :synopsis: async heapq variants
+
+The :py:mod:`asyncstdlib.heapq` library implements
+Python's :py:mod:`heapq` for (async) functions and (async) iterables.
+
+.. versionadded:: 3.10.3
+
+This module does not re-implement the functions to maintain a heap data structure.
+Since Python's :py:mod:`heapq` module does not support an internal ``key`` function
+but relies on ``(key, item)`` pairs as needed,
+the same interface can be used for ``async`` key function.
+For example, an ``async`` key function would be used as
+``heappush(heap, (await key_func(item), item))`` instead of
+``heappush(heap, (key_func(item), item))``.
+
+Iterator merging
+================
+
+.. autofunction:: merge(*iterables: (async) iter T, key: (T) → (await) Any = None, reverse: bool = False)
+    :async-for: :T
+
+Iterator selecting
+==================
+
+.. autofunction:: nlargest(*iterables: (async) iter T, n: int, key: (T) → (await) Any = None) -> [T, ...]
+
+.. autofunction:: nsmallest(*iterables: (async) iter T, n: int, key: (T) → (await) Any = None) -> [T, ...]
+

--- a/unittests/test_heapq.py
+++ b/unittests/test_heapq.py
@@ -45,3 +45,41 @@ async def test_merge_stdlib_key(samples, reverse):
             *map(asyncify, samples), key=awaitify(lambda x: -x), reverse=reverse
         )
     ]
+
+
+MINMAX_SAMPLES = [
+    [0, 3, 1, 4, 2, 5],
+    [0, -3, 1, -4, -2, 5],
+    # [i * 1.1 for i in range(20)],
+    # [random.randint(-5, 5) in range(20)],
+    # [i * i if i % 3 else -i * i for i in range(2000)],
+]
+
+
+@pytest.mark.parametrize("sample", MINMAX_SAMPLES)
+@pytest.mark.parametrize("n", [0, 1, 2, 10, 100, 400, 999, 1000, 1100])
+@sync
+async def test_nsmallest_stdlib(sample, n):
+    assert heapq.nsmallest(n, sample) == await a.nsmallest(asyncify(sample), n)
+
+
+@pytest.mark.parametrize("sample", MINMAX_SAMPLES)
+@pytest.mark.parametrize("n", [0, 1, 2, 10, 100, 400, 999, 1000, 1100])
+@sync
+async def test_nlargest_stdlib(sample, n):
+    assert heapq.nlargest(n, sample) == await a.nlargest(asyncify(sample), n)
+
+
+
+@pytest.mark.parametrize("sample", MINMAX_SAMPLES)
+@pytest.mark.parametrize("n", [0, 1, 2, 10, 100, 400, 999, 1000, 1100])
+@sync
+async def test_nsmallest_stdlib_key(sample, n):
+    assert heapq.nsmallest(n, sample, key=lambda x: -x) == await a.nsmallest(asyncify(sample), n, key=lambda x: -x)
+
+
+@pytest.mark.parametrize("sample", MINMAX_SAMPLES)
+@pytest.mark.parametrize("n", [0, 1, 2, 10, 100, 400, 999, 1000, 1100])
+@sync
+async def test_nlargest_stdlib(sample, n):
+    assert heapq.nlargest(n, sample, key=lambda x: -x) == await a.nlargest(asyncify(sample), n, key=lambda x: -x)

--- a/unittests/test_heapq.py
+++ b/unittests/test_heapq.py
@@ -82,7 +82,7 @@ async def test_nsmallest_stdlib_key(sample, n):
 @pytest.mark.parametrize("sample", MINMAX_SAMPLES)
 @pytest.mark.parametrize("n", [0, 1, 2, 10, 100, 400, 999, 1000, 1100])
 @sync
-async def test_nlargest_stdlib(sample, n):
+async def test_nlargest_stdlib_key(sample, n):
     assert heapq.nlargest(n, sample, key=lambda x: -x) == await a.nlargest(
         asyncify(sample), n, key=lambda x: -x
     )

--- a/unittests/test_heapq.py
+++ b/unittests/test_heapq.py
@@ -70,16 +70,19 @@ async def test_nlargest_stdlib(sample, n):
     assert heapq.nlargest(n, sample) == await a.nlargest(asyncify(sample), n)
 
 
-
 @pytest.mark.parametrize("sample", MINMAX_SAMPLES)
 @pytest.mark.parametrize("n", [0, 1, 2, 10, 100, 400, 999, 1000, 1100])
 @sync
 async def test_nsmallest_stdlib_key(sample, n):
-    assert heapq.nsmallest(n, sample, key=lambda x: -x) == await a.nsmallest(asyncify(sample), n, key=lambda x: -x)
+    assert heapq.nsmallest(n, sample, key=lambda x: -x) == await a.nsmallest(
+        asyncify(sample), n, key=lambda x: -x
+    )
 
 
 @pytest.mark.parametrize("sample", MINMAX_SAMPLES)
 @pytest.mark.parametrize("n", [0, 1, 2, 10, 100, 400, 999, 1000, 1100])
 @sync
 async def test_nlargest_stdlib(sample, n):
-    assert heapq.nlargest(n, sample, key=lambda x: -x) == await a.nlargest(asyncify(sample), n, key=lambda x: -x)
+    assert heapq.nlargest(n, sample, key=lambda x: -x) == await a.nlargest(
+        asyncify(sample), n, key=lambda x: -x
+    )

--- a/unittests/test_heapq.py
+++ b/unittests/test_heapq.py
@@ -1,0 +1,47 @@
+import heapq
+
+import pytest
+import random
+
+import asyncstdlib as a
+
+from .utility import sync, asyncify, awaitify
+
+
+MERGE_SAMPLES = [
+    [[1, 2], [3, 4]],
+    [[1, 2, 3], [4, 5, 6], [7, 8, 9]],
+    [[1, 4, 7], [2, 5, 8], [3, 6, 9]],
+    [[1], [2, 3], [4, 5, 6], [7, 8, 9]],
+    [[1], [2, 4, 6], [3], [5, 7, 8, 9]],
+    [[1, 2, 3, 4] for _ in range(3)],
+    [sorted(random.random() for _ in range(5)) for _ in range(5)],
+    [[], []],
+    [[]],
+]
+
+
+@pytest.mark.parametrize("samples", MERGE_SAMPLES)
+@pytest.mark.parametrize("reverse", [False, True])
+@sync
+async def test_merge_stdlib(samples, reverse):
+    """Compare `heapq.merge` against stdlib implementation"""
+    samples = samples if not reverse else [sample[::-1] for sample in samples]
+    assert list(heapq.merge(*samples, reverse=reverse)) == [
+        item async for item in a.merge(*map(asyncify, samples), reverse=reverse)
+    ]
+
+
+@pytest.mark.parametrize("samples", MERGE_SAMPLES)
+@pytest.mark.parametrize("reverse", [False, True])
+@sync
+async def test_merge_stdlib_key(samples, reverse):
+    """Compare `heapq.merge` with key against stdlib implementation"""
+    # use a key that reverses the result => must reverse input
+    samples = samples if reverse else [sample[::-1] for sample in samples]
+    assert list(heapq.merge(*samples, key=lambda x: -x, reverse=reverse)) == [
+        item
+        async for item in a.merge(
+            *map(asyncify, samples), key=awaitify(lambda x: -x), reverse=reverse
+        )
+    ]


### PR DESCRIPTION
This PR adds async variants of the ``heapq`` module. Notable changes include:

* ``heapq.merge`` for merging multiple pre-sorted (async) iterables efficiently
* ``heapq.nsmallest`` and ``heapq.nlargest`` to efficiently get the smallest/largest items of an (async) iterable

Closes #57.