### PR TITLE
Use flit_core build-backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["flit"]
-build-backend = "flit.buildapi"
+requires = ["flit_core"]
+build-backend = "flit_core.buildapi"
 
 [tool.flit.metadata]
 module = "asyncstdlib"


### PR DESCRIPTION
* use flit_core instead of flit as recommended upstream

The end result is the same (i.e. it produces identical bdist and sdist), yet flit_core pulls less dependencies and is therefore much faster.