### PR TITLE
Add strong async neutral iteration

### DIFF
--- a/asyncstdlib/__init__.py
+++ b/asyncstdlib/__init__.py
@@ -33,7 +33,7 @@ from .itertools import (
     zip_longest,
     groupby,
 )
-from .asynctools import borrow, scoped_iter, await_each, apply, sync
+from .asynctools import borrow, scoped_iter, await_each, any_iter, apply, sync
 from .heapq import merge, nlargest, nsmallest
 
 __version__ = "3.10.2"
@@ -82,6 +82,7 @@ __all__ = [
     "borrow",
     "scoped_iter",
     "await_each",
+    "any_iter",
     "apply",
     "sync",
     # heapq

--- a/asyncstdlib/asynctools.py
+++ b/asyncstdlib/asynctools.py
@@ -394,13 +394,13 @@ async def any_iter(
     Provide an async iterator for various forms of "asynchronous iterable"
 
     Useful to uniformly handle async iterables, awaitable iterables, iterables of
-    awaitables and similar in an ``async for`` loop. Among other things, this
+    awaitables, and similar in an ``async for`` loop. Among other things, this
     matches all forms of ``async def`` functions providing iterables.
 
     .. code-block:: python3
 
         import random
-        import asyncstdlib.asynctools as a
+        import asyncstdlib as a
 
         # AsyncIterator[T]
         async def async_iter(n):

--- a/asyncstdlib/asynctools.py
+++ b/asyncstdlib/asynctools.py
@@ -414,6 +414,12 @@ async def any_iter(
         some_iter = random.choice([async_iter, await_iter, range])
         async for item in a.any_iter(some_iter(4)):
             print(item)
+
+    This function must eagerly resolve each "async layer" before checking if
+    the next layer is as expected. This incurs a performance penalty and
+    non-iterables may be left unusable by this.
+    Prefer :py:func:`~.builtins.iter` to test for iterables with :term:`EAFP`
+    and for performance when only simple iterables need handling.
     """
     iterable = __iter if not isinstance(__iter, Awaitable) else await __iter
     if isinstance(iterable, AsyncIterable):

--- a/asyncstdlib/asynctools.py
+++ b/asyncstdlib/asynctools.py
@@ -416,7 +416,7 @@ async def any_iter(
             print(item)
     """
     iterable = __iter if not isinstance(__iter, Awaitable) else await __iter
-    if isinstance(__iter, AsyncIterable):
+    if isinstance(iterable, AsyncIterable):
         async for item in iterable:
             yield item if not isinstance(item, Awaitable) else await item
     else:

--- a/asyncstdlib/asynctools.py
+++ b/asyncstdlib/asynctools.py
@@ -394,8 +394,8 @@ async def any_iter(
     Provide an async iterator for various forms of "asynchronous iterable"
 
     Useful to uniformly handle async iterables, awaitable iterables, iterables of
-    awaitables and similar. Among other things, this matches all forms of
-    ``async def`` functions providing iterables.
+    awaitables and similar in an ``async for`` loop. Among other things, this
+    matches all forms of ``async def`` functions providing iterables.
 
     .. code-block:: python3
 

--- a/docs/source/api/asynctools.rst
+++ b/docs/source/api/asynctools.rst
@@ -27,6 +27,11 @@ Async transforming
 
     .. versionadded:: 3.9.3
 
+.. autofunction:: any_iter(iter: (await) (async) iter (await) T)
+    :async-for: :T
+
+    .. versionadded:: 3.10.3
+
 .. autofunction:: await_each(awaitables: iter await T)
     :async-for: :T
 

--- a/unittests/test_asynctools.py
+++ b/unittests/test_asynctools.py
@@ -284,4 +284,4 @@ async def await_async_iter_await(n: int):
 @sync
 async def test_any_iter(n, any_iterable_t):
     iterable = any_iterable_t(n)
-    assert [item async for item in a.asynctools.any_iter(iterable)] == [*range(n)]
+    assert [item async for item in a.any_iter(iterable)] == [*range(n)]


### PR DESCRIPTION
This PR adds an async helper for async neutral iteration. Notable changes include:

* ``asynctools.any_iter`` for normalising ``(await) (async) iter (await) T`` to just ``async iter T``

See #77.