### PR TITLE
Allow evicting individual items from lru_cache

### DIFF
--- a/asyncstdlib/_lrucache.py
+++ b/asyncstdlib/_lrucache.py
@@ -286,7 +286,7 @@ class CallKey:
 
 def cache__get(
     self: LRUAsyncCallable[AC], instance: object, owner: Optional[type] = None
-) -> Union[LRUAsyncCallable[AC], LRUAsyncBoundCallable[AC]]:
+) -> LRUAsyncCallable[AC]:
     """Descriptor ``__get__`` for caches to bind them on lookup"""
     if instance is None:
         return self

--- a/asyncstdlib/_lrucache.py
+++ b/asyncstdlib/_lrucache.py
@@ -119,6 +119,10 @@ class LRUAsyncBoundCallable(LRUAsyncCallable[AC]):
     def cache_discard(self, *args, **kwargs) -> None:
         return self.__lru.cache_discard(self.__self__, *args, **kwargs)
 
+    def __repr__(self):
+        name = getattr(self.__wrapped__, "__qualname__", "?")
+        return f"<bound async cache {name} of {self.__self__}>"
+
 
 @overload
 def lru_cache(maxsize: AC, typed: bool = ...) -> LRUAsyncCallable[AC]:

--- a/asyncstdlib/_lrucache.py
+++ b/asyncstdlib/_lrucache.py
@@ -132,14 +132,14 @@ def lru_cache(
     """
     Least Recently Used cache for async functions
 
-    Applies an LRU cache, mapping the most recent function call arguments
-    to the *awaited* function return value. This makes this cache appropriate for
-    :term:`coroutine functions <coroutine function>`, :py:func:`~functools.partial`
-    coroutines and any other callable that returns an :term:`awaitable`.
+    Applies an LRU cache storing call arguments and their *awaited* return value.
+    This is appropriate for :term:`coroutine functions <coroutine function>`,
+    :py:func:`~functools.partial` coroutines and any other callable that returns
+    an :term:`awaitable`.
 
-    Arguments to the cached function must be :term:`hashable`. On a successful cache
-    hit, the underlying function is *not* called. This means any side-effects, including
-    scheduling in an internal event loop, are skipped. Ideally, ``lru_cache`` is used
+    Arguments to the cached function must be :term:`hashable`; when the arguments are
+    in the cache, the underlying function is *not* called. This means any side-effects,
+    including scheduling in an event loop, are skipped. Ideally, ``lru_cache`` is used
     for long-running queries or requests that return the same result for the same input.
 
     The maximum number of cached items is defined by ``maxsize``:
@@ -155,19 +155,20 @@ def lru_cache(
       argument pattern adds an entry to the cache; patterns and values are never
       automatically evicted.
 
-    The cache can always be explicitly emptied via
-    :py:meth:`~LRUAsyncCallable.cache_clear`.
+    In addition to automatic cache eviction from ``maxsize``, the cache can be
+    explicitly emptied via :py:meth:`~LRUAsyncCallable.cache_clear`.
     Use the cache's :py:meth:`~LRUAsyncCallable.cache_info` to inspect the cache's
     performance and filling level.
 
     If ``typed`` is :py:data:`True`, values in argument patterns are compared by
-    value *and* type. For example, this means that passing ``3`` and ``3.0`` as
-    the same argument are treated as distinct pattern elements.
+    value *and* type. For example, this means ``3`` and ``3.0`` are treated as
+    distinct arguments; however, this is not applied recursively so the type of
+    both ``(3, 4)`` and ``(3.0, 4.0)`` is the same.
 
     .. note::
 
-        This wrapper is intended for use with a single event loop, and supports
-        overlapping concurrent calls.
+        This LRU cache supports overlapping ``await`` calls, provided that the
+        wrapped async function does as well.
         Unlike the original :py:func:`functools.lru_cache`, it is not thread-safe.
     """
     if isinstance(maxsize, int):

--- a/asyncstdlib/_lrucache.py
+++ b/asyncstdlib/_lrucache.py
@@ -82,6 +82,9 @@ class LRUAsyncCallable(Protocol[AC]):
     def cache_clear(self) -> None:
         """Evict all call argument patterns and their results from the cache"""
 
+    def cache_discard(self, *args, **kwargs) -> None:
+        """Evict the call argument pattern and its result from the cache"""
+
 
 @public_module("asyncstdlib.functools")
 class LRUAsyncBoundCallable(LRUAsyncCallable[AC]):
@@ -111,6 +114,9 @@ class LRUAsyncBoundCallable(LRUAsyncCallable[AC]):
 
     def cache_clear(self) -> None:
         return self.__lru.cache_clear()
+
+    def cache_discard(self, *args, **kwargs) -> None:
+        return self.__lru.cache_discard(self.__self__, *args, **kwargs)
 
 
 @overload
@@ -279,6 +285,9 @@ class UncachedLRUAsyncCallable(LRUAsyncCallable[AC]):
     def cache_clear(self) -> None:
         self.__misses = 0
 
+    def cache_discard(self, *args, **kwargs) -> None:
+        return
+
 
 @public_module("asyncstdlib.functools")
 class MemoizedLRUAsyncCallable(LRUAsyncCallable[AC]):
@@ -320,6 +329,9 @@ class MemoizedLRUAsyncCallable(LRUAsyncCallable[AC]):
         self.__hits = 0
         self.__misses = 0
         self.__cache.clear()
+
+    def cache_discard(self, *args, **kwargs) -> None:
+        self.__cache.pop(CallKey.from_call(args, kwargs, typed=self.__typed), None)
 
 
 @public_module("asyncstdlib.functools")
@@ -373,3 +385,6 @@ class CachedLRUAsyncCallable(LRUAsyncCallable[AC]):
         self.__hits = 0
         self.__misses = 0
         self.__cache.clear()
+
+    def cache_discard(self, *args, **kwargs) -> None:
+        self.__cache.pop(CallKey.from_call(args, kwargs, typed=self.__typed), None)

--- a/asyncstdlib/_lrucache.py
+++ b/asyncstdlib/_lrucache.py
@@ -89,6 +89,7 @@ class LRUAsyncCallable(Protocol[AC]):
 @public_module("asyncstdlib.functools")
 class LRUAsyncBoundCallable(LRUAsyncCallable[AC]):
     """A :py:class:`~.LRUAsyncCallable` that is bound like a method"""
+
     __slots__ = ("__lru", "__self__")
 
     def __init__(self, lru: LRUAsyncCallable[AC], __self__):
@@ -181,9 +182,7 @@ def lru_cache(
         maxsize = 0 if maxsize < 0 else maxsize
     elif callable(maxsize):
         # used as function decorator, first arg is the function to be wrapped
-        fast_wrapper = CachedLRUAsyncCallable(
-            cast(AC, maxsize), typed, 128,
-        )
+        fast_wrapper = CachedLRUAsyncCallable(cast(AC, maxsize), typed, 128)
         return update_wrapper(fast_wrapper, maxsize)
     elif maxsize is not None:
         raise TypeError(
@@ -264,6 +263,7 @@ def cache__get(self, instance, owner):
 @public_module("asyncstdlib.functools")
 class UncachedLRUAsyncCallable(LRUAsyncCallable[AC]):
     """Wrap the async ``call`` to track accesses as for caching/memoization"""
+
     __slots__ = ("__wrapped__", "__misses", "__typed")
 
     __get__ = cache__get
@@ -293,6 +293,7 @@ class UncachedLRUAsyncCallable(LRUAsyncCallable[AC]):
 @public_module("asyncstdlib.functools")
 class MemoizedLRUAsyncCallable(LRUAsyncCallable[AC]):
     """Wrap the async ``call`` with async memoization"""
+
     __slots__ = ("__wrapped__", "__hits", "__misses", "__typed", "__cache")
 
     __get__ = cache__get
@@ -338,6 +339,7 @@ class MemoizedLRUAsyncCallable(LRUAsyncCallable[AC]):
 @public_module("asyncstdlib.functools")
 class CachedLRUAsyncCallable(LRUAsyncCallable[AC]):
     """Wrap the async ``call`` with async LRU caching of finite capacity"""
+
     __slots__ = ("__wrapped__", "__hits", "__misses", "__typed", "__maxsize", "__cache")
 
     __get__ = cache__get

--- a/asyncstdlib/_lrucache.py
+++ b/asyncstdlib/_lrucache.py
@@ -83,7 +83,17 @@ class LRUAsyncCallable(Protocol[AC]):
         """Evict all call argument patterns and their results from the cache"""
 
     def cache_discard(self, *args, **kwargs) -> None:
-        """Evict the call argument pattern and its result from the cache"""
+        """
+        Evict the call argument pattern and its result from the cache
+
+        When a cache is wrapped by another :term:`descriptor`
+        (``property``, ``staticmethod``, ...),
+        the descriptor must support wrapping descriptors for this method
+        to detect implicit arguments such as ``self``.
+        """
+        # "support wrapping descriptors" means that the wrapping descriptor has to use
+        # the cache as a descriptor as well, i.e. invoke its ``__get__`` method instead
+        # of just passing in `self`/`cls`/... directly.
 
 
 @public_module("asyncstdlib.functools")
@@ -155,19 +165,20 @@ def lru_cache(
 
     The maximum number of cached items is defined by ``maxsize``:
 
-    * If set to a positive integer, at most ``maxsize`` distinct function argument
-      patterns are stored; further calls with *different* patterns evict the oldest
-      stored pattern from the cache.
+    * If set to a positive integer, up to ``maxsize`` function argument
+      patterns are stored; further calls with *different* patterns replace the oldest
+      pattern in the cache.
 
     * If set to zero or a negative integer, the cache is disabled. Every call is
       directly forwarded to the underlying function, and counted as a cache miss.
 
-    * If set to :py:data:`None`, the cache has unlimited size. Every new function
-      argument pattern adds an entry to the cache; patterns and values are never
+    * If set to :py:data:`None`, the cache has unlimited size. Every used function
+      argument pattern adds an entry to the cache; patterns are never
       automatically evicted.
 
     In addition to automatic cache eviction from ``maxsize``, the cache can be
-    explicitly emptied via :py:meth:`~LRUAsyncCallable.cache_clear`.
+    explicitly emptied via :py:meth:`~LRUAsyncCallable.cache_clear`
+    and :py:meth:`~LRUAsyncCallable.cache_discard`.
     Use the cache's :py:meth:`~LRUAsyncCallable.cache_info` to inspect the cache's
     performance and filling level.
 

--- a/asyncstdlib/_lrucache.py
+++ b/asyncstdlib/_lrucache.py
@@ -256,8 +256,9 @@ class CallKey:
 
 def cache__get(self, instance, owner):
     """Descriptor ``__get__`` for caches to bind them on lookup"""
-    bound_wrapped = self.__wrapped__.__get__(instance, owner)
-    return LRUAsyncBoundCallable(self, bound_wrapped.__self__)
+    if instance is None:
+        return self
+    return LRUAsyncBoundCallable(self, instance)
 
 
 @public_module("asyncstdlib.functools")

--- a/asyncstdlib/_lrucache.py
+++ b/asyncstdlib/_lrucache.py
@@ -85,18 +85,23 @@ class LRUAsyncCallable(Protocol[AC]):
 
 @public_module("asyncstdlib.functools")
 class LRUAsyncBoundCallable(LRUAsyncCallable[AC]):
-    __slots__ = ("__lru", "__self")
+    """A :py:class:`~.LRUAsyncCallable` that is bound like a method"""
+    __slots__ = ("__lru", "__self__")
 
     def __init__(self, lru: LRUAsyncCallable[AC], __self__):
         self.__lru = lru
-        self.__self = __self__
+        self.__self__ = __self__
 
     @property
     def __wrapped__(self):
         return self.__lru.__wrapped__
 
+    @property
+    def __func__(self):
+        return self.__lru
+
     def __call__(self, *args, **kwargs):
-        return self.__lru(self.__self, *args, **kwargs)
+        return self.__lru(self.__self__, *args, **kwargs)
 
     def cache_parameters(self) -> CacheParameters:
         return self.__lru.cache_parameters()

--- a/asyncstdlib/_lrucache.py
+++ b/asyncstdlib/_lrucache.py
@@ -64,7 +64,7 @@ class LRUAsyncCallable(Protocol[AC]):
     :py:class:`~typing.Protocol` of a LRU cache wrapping a callable to an awaitable
     """
 
-    __slots__: Tuple[str, ...] = ("__weakref__",)
+    __slots__: Tuple[str, ...] = ()
 
     @property
     def __wrapped__(self) -> AC:
@@ -104,7 +104,7 @@ class LRUAsyncCallable(Protocol[AC]):
 class LRUAsyncBoundCallable(LRUAsyncCallable[AC]):
     """A :py:class:`~.LRUAsyncCallable` that is bound like a method"""
 
-    __slots__ = ("_lru", "__self__")
+    __slots__ = ("__weakref__", "_lru", "__self__")
 
     def __init__(self, lru: LRUAsyncCallable[AC], __self__: object):
         self._lru = lru
@@ -297,7 +297,7 @@ def cache__get(
 class UncachedLRUAsyncCallable(LRUAsyncCallable[AC]):
     """Wrap the async ``call`` to track accesses as for caching/memoization"""
 
-    __slots__ = ("__dict__", "__wrapped__", "__misses", "__typed")
+    __slots__ = ("__weakref__", "__dict__", "__wrapped__", "__misses", "__typed")
 
     __get__ = cache__get
 
@@ -327,7 +327,15 @@ class UncachedLRUAsyncCallable(LRUAsyncCallable[AC]):
 class MemoizedLRUAsyncCallable(LRUAsyncCallable[AC]):
     """Wrap the async ``call`` with async memoization"""
 
-    __slots__ = ("__dict__", "__wrapped__", "__hits", "__misses", "__typed", "__cache")
+    __slots__ = (
+        "__weakref__",
+        "__dict__",
+        "__wrapped__",
+        "__hits",
+        "__misses",
+        "__typed",
+        "__cache",
+    )
 
     __get__ = cache__get
 
@@ -374,6 +382,7 @@ class CachedLRUAsyncCallable(LRUAsyncCallable[AC]):
     """Wrap the async ``call`` with async LRU caching of finite capacity"""
 
     __slots__ = (
+        "__weakref__",
         "__dict__",
         "__wrapped__",
         "__hits",

--- a/docs/source/api/functools.rst
+++ b/docs/source/api/functools.rst
@@ -30,6 +30,11 @@ of :py:mod:`asyncstdlib` work only with async callables
 Notably, they also work with regular callables that return an :term:`awaitable`,
 such as an ``async def`` function wrapped by :py:func:`~functools.partial`.
 
+.. autofunction:: cached_property(getter: (Self) → await T)
+    :decorator:
+
+    .. versionadded:: 1.1.0
+
 The caches track *call argument patterns* and their return values.
 A pattern is an *ordered* representation of positional and keyword arguments;
 notably, this disregards defaults and overlap between positional and keyword arguments.
@@ -38,11 +43,6 @@ and ``f(b=2, a=1)`` are considered three distinct patterns.
 
 In addition, exceptions are not return values. This allows retrying a long-running
 query that may fail, caching any *eventual* result for quick and reliable lookup.
-
-.. autofunction:: cached_property(getter: (Self) → await T)
-    :decorator:
-
-    .. versionadded:: 1.1.0
 
 The :py:func:`~asyncstdlib.functools.lru_cache`
 can be applied as a decorator, both with and without arguments:

--- a/docs/source/api/functools.rst
+++ b/docs/source/api/functools.rst
@@ -27,8 +27,17 @@ Both :py:func:`~asyncstdlib.functools.lru_cache`
 and :py:func:`~asyncstdlib.functools.cached_property`
 of :py:mod:`asyncstdlib` work only with async callables
 (they are not :term:`async neutral`).
-Notably, this includes regular callables that return an :term:`awaitable`,
+Notably, they also work with regular callables that return an :term:`awaitable`,
 such as an ``async def`` function wrapped by :py:func:`~functools.partial`.
+
+The caches track *call argument patterns* and their return values.
+A pattern is an *ordered* representation of positional and keyword arguments;
+notably, this disregards defaults and overlap between positional and keyword arguments.
+This means that for a function ``f(a, b)``, the calls ``f(1, 2)``, ``f(a=1, b=2)``
+and ``f(b=2, a=1)`` are considered three distinct patterns.
+
+In addition, exceptions are not return values. This allows retrying a long-running
+query that may fail, caching any *eventual* result for quick and reliable lookup.
 
 .. autofunction:: cached_property(getter: (Self) → await T)
     :decorator:
@@ -60,16 +69,6 @@ can be applied as a decorator, both with and without arguments:
 .. autofunction:: lru_cache(maxsize: ?int = 128, typed: bool = False)((...) -> await R)
     :decorator:
 
-The cache tracks *call argument patterns* and maps them to observed return values.
-A pattern is an *ordered* representation of provided positional and keyword arguments;
-notably, this disregards default arguments, as well as any overlap between
-positional and keyword arguments.
-This means that for a function ``f(a, b)``, the calls ``f(1, 2)``, ``f(a=1, b=2)``
-and ``f(b=2, a=1)`` are considered three distinct patterns.
-
-In addition, exceptions are not return values. This allows retrying a long-running
-query that may fail, caching any *eventual* result for quick and reliable lookup.
-
 A wrapped async callable can be queried for its cache metadata,
 and allows clearing the entire cache. This can be useful to explicitly monitor
 cache performance, and to manage caches of unrestricted size.
@@ -93,3 +92,7 @@ the ``__wrapped__`` callable may be wrapped with a new cache of different size.
     .. versionadded:: 3.9.0
 
         The :py:meth:`~.cache_parameters` method.
+
+    .. versionadded:: 3.10.4
+
+        The :py:meth:`~.cache_discard` method.

--- a/docs/source/api/functools.rst
+++ b/docs/source/api/functools.rst
@@ -30,49 +30,45 @@ of :py:mod:`asyncstdlib` work only with async callables
 Notably, they also work with regular callables that return an :term:`awaitable`,
 such as an ``async def`` function wrapped by :py:func:`~functools.partial`.
 
+Attribute Caches
+----------------
+
+This type of cache tracks ``await``\ ing an attribute.
+
 .. autofunction:: cached_property(getter: (Self) → await T)
     :decorator:
 
     .. versionadded:: 1.1.0
 
-The caches track *call argument patterns* and their return values.
+Callable Caches
+---------------
+
+This type of cache tracks *call argument patterns* and their return values.
 A pattern is an *ordered* representation of positional and keyword arguments;
 notably, this disregards defaults and overlap between positional and keyword arguments.
 This means that for a function ``f(a, b)``, the calls ``f(1, 2)``, ``f(a=1, b=2)``
 and ``f(b=2, a=1)`` are considered three distinct patterns.
 
-In addition, exceptions are not return values. This allows retrying a long-running
-query that may fail, caching any *eventual* result for quick and reliable lookup.
+Note that exceptions are not considered return values and thus never cached. This makes
+the caches suitable for queries that may fail, caching any *eventual* result for
+quick and reliable lookup.
 
-The :py:func:`~asyncstdlib.functools.lru_cache`
-can be applied as a decorator, both with and without arguments:
-
-.. code-block:: python3
-
-    @a.lru_cache
-    async def get_pep(num):
-        url = f'http://www.python.org/dev/peps/pep-{num:04}/'
-        request = await asynclib.get(url)
-        return request.body()
-
-    @a.lru_cache(maxsize=32)
-    async def get_pep(num):
-        url = f'http://www.python.org/dev/peps/pep-{num:04}/'
-        request = await asynclib.get(url)
-        return request.body()
-
-.. autofunction:: cache((...) -> await R)
+.. autofunction:: cache((...) → await R) -> LRUAsyncCallable
     :decorator:
 
     .. versionadded:: 3.9.0
 
-.. autofunction:: lru_cache(maxsize: ?int = 128, typed: bool = False)((...) -> await R)
+.. py:function:: lru_cache((...) → await R) -> LRUAsyncCallable
+    :decorator:
+    :noindex:
+
+.. autofunction:: lru_cache(maxsize: ?int = 128, typed: bool = False)((...) → await R) -> LRUAsyncCallable
     :decorator:
 
-A wrapped async callable can be queried for its cache metadata,
-and allows clearing the entire cache. This can be useful to explicitly monitor
-cache performance, and to manage caches of unrestricted size.
-Note that the ``maxsize`` of a cache cannot be changed at runtime -- however,
+A cached async callable can be queried for its cache metadata and allows clearing
+entries from the cache. This can be useful to explicitly monitor cache performance,
+and to manage caches of unrestricted size.
+While the ``maxsize`` of a cache cannot be changed at runtime,
 the ``__wrapped__`` callable may be wrapped with a new cache of different size.
 
 .. autoclass:: LRUAsyncCallable()
@@ -85,14 +81,15 @@ the ``__wrapped__`` callable may be wrapped with a new cache of different size.
 
     .. automethod:: cache_clear()
 
+    .. automethod:: cache_discard(...)
+
+        .. versionchanged:: Python3.9
+            :py:func:`classmethod` properly wraps caches.
+
+        .. versionadded:: 3.10.4
+
     .. automethod:: cache_info() -> (hits=..., misses=..., maxsize=..., currsize=...)
 
     .. automethod:: cache_parameters() -> {"maxsize": ..., "typed": ...}
 
-    .. versionadded:: 3.9.0
-
-        The :py:meth:`~.cache_parameters` method.
-
-    .. versionadded:: 3.10.4
-
-        The :py:meth:`~.cache_discard` method.
+        .. versionadded:: 3.9.0

--- a/unittests/test_functools_lru.py
+++ b/unittests/test_functools_lru.py
@@ -95,7 +95,7 @@ async def test_method_discard(size, counter_factory):
     """Test caching with resetting specific item"""
     counter_type = counter_factory(size)
     if (
-        sys.version_info <= (3, 8)
+        sys.version_info < (3, 9)
         and type(counter_type.__dict__["count"]) is classmethod
     ):
         pytest.skip("classmethod does not respect descriptors up to 3.8")

--- a/unittests/test_functools_lru.py
+++ b/unittests/test_functools_lru.py
@@ -1,24 +1,28 @@
+import pytest
+
 import asyncstdlib as a
 
 from .utility import sync
 
 
+@pytest.mark.parametrize("size", [0, 3, 10, None])
 @sync
-async def test_method():
+async def test_method(size):
     """Test wrapping a method"""
 
     class Counter:
         def __init__(self):
             self._count = 0
 
-        @a.lru_cache
+        @a.lru_cache(maxsize=size)
         async def count(self):
             self._count += 1
             return self._count
 
     for _instance in range(4):
         instance = Counter()
-        for _reset in range(5):
-            for _access in range(5):
-                assert _reset + 1 == await instance.count()
+        for reset in range(5):
+            for access in range(5):
+                misses = reset + 1 if size != 0 else reset * 5 + access + 1
+                assert misses == await instance.count()
             instance.count.cache_clear()

--- a/unittests/test_functools_lru.py
+++ b/unittests/test_functools_lru.py
@@ -19,8 +19,32 @@ async def test_method(size):
             self._count += 1
             return self._count
 
+    await _test_counting(size, Counter)
+
+
+@pytest.mark.parametrize("size", [0, 3, 10, None])
+@sync
+async def test_classmethod(size):
+    """Test wrapping a method"""
+
+    class Counter:
+        _count = 0
+
+        def __init__(self):
+            type(self)._count = 0
+
+        @classmethod
+        @a.lru_cache(maxsize=size)
+        async def count(cls):
+            cls._count += 1
+            return cls._count
+
+    await _test_counting(size, Counter)
+
+
+async def _test_counting(size, counter_type):
     for _instance in range(4):
-        instance = Counter()
+        instance = counter_type()
         for reset in range(5):
             for access in range(5):
                 misses = reset + 1 if size != 0 else reset * 5 + access + 1

--- a/unittests/test_functools_lru.py
+++ b/unittests/test_functools_lru.py
@@ -72,25 +72,25 @@ async def test_method(size, counter_factory):
                 misses = 1 if size != 0 else reset * 5 + access + 1
                 assert misses == await instance.count()
     counter_type.count.cache_clear()
-    # classmethod does not respect descriptors up to 3.8
-    if sys.version_info >= (3, 9) or not isinstance(
-        counter_type.__dict__["count"], classmethod
-    ):
-        # caching with resetting everything
-        for _instance in range(4):
-            instance = counter_type()
-            for reset in range(5):
-                for access in range(5):
-                    misses = reset + 1 if size != 0 else reset * 5 + access + 1
-                    assert misses == await instance.count()
-                instance.count.cache_clear()
-        counter_type.count.cache_clear()
-    # caching with resetting specific item
+    # caching with resetting everything
     for _instance in range(4):
         instance = counter_type()
         for reset in range(5):
             for access in range(5):
-                misses = reset * 5 + access + 1
+                misses = reset + 1 if size != 0 else reset * 5 + access + 1
                 assert misses == await instance.count()
-                instance.count.cache_discard()
+            instance.count.cache_clear()
+    counter_type.count.cache_clear()
+    # classmethod does not respect descriptors up to 3.8
+    if sys.version_info >= (3, 9) or not isinstance(
+        counter_type.__dict__["count"], classmethod
+    ):
+        # caching with resetting specific item
+        for _instance in range(4):
+            instance = counter_type()
+            for reset in range(5):
+                for access in range(5):
+                    misses = reset * 5 + access + 1
+                    assert misses == await instance.count()
+                    instance.count.cache_discard()
     counter_type.count.cache_clear()

--- a/unittests/test_functools_lru.py
+++ b/unittests/test_functools_lru.py
@@ -1,0 +1,24 @@
+import asyncstdlib as a
+
+from .utility import sync
+
+
+@sync
+async def test_method():
+    """Test wrapping a method"""
+
+    class Counter:
+        def __init__(self):
+            self._count = 0
+
+        @a.lru_cache
+        async def count(self):
+            self._count += 1
+            return self._count
+
+    for _instance in range(4):
+        instance = Counter()
+        for _reset in range(5):
+            for _access in range(5):
+                assert _reset + 1 == await instance.count()
+            instance.count.cache_clear()

--- a/unittests/test_functools_lru.py
+++ b/unittests/test_functools_lru.py
@@ -55,10 +55,11 @@ def staticmethod_counter(size):
     return Counter
 
 
+counter_factories = [method_counter, classmethod_counter, staticmethod_counter]
+
+
 @pytest.mark.parametrize("size", [0, 3, 10, None])
-@pytest.mark.parametrize(
-    "counter_factory", [method_counter, classmethod_counter, staticmethod_counter]
-)
+@pytest.mark.parametrize("counter_factory", counter_factories)
 @sync
 async def test_method_plain(size, counter_factory):
     """Test caching without resetting"""
@@ -73,9 +74,7 @@ async def test_method_plain(size, counter_factory):
 
 
 @pytest.mark.parametrize("size", [0, 3, 10, None])
-@pytest.mark.parametrize(
-    "counter_factory", [method_counter, classmethod_counter, staticmethod_counter]
-)
+@pytest.mark.parametrize("counter_factory", counter_factories)
 @sync
 async def test_method_clear(size, counter_factory):
     """Test caching with resetting everything"""
@@ -90,9 +89,7 @@ async def test_method_clear(size, counter_factory):
 
 
 @pytest.mark.parametrize("size", [0, 3, 10, None])
-@pytest.mark.parametrize(
-    "counter_factory", [method_counter, classmethod_counter, staticmethod_counter]
-)
+@pytest.mark.parametrize("counter_factory", counter_factories)
 @sync
 async def test_method_discard(size, counter_factory):
     """Test caching with resetting specific item"""
@@ -112,9 +109,7 @@ async def test_method_discard(size, counter_factory):
 
 
 @pytest.mark.parametrize("size", [0, 3, 10, None])
-@pytest.mark.parametrize(
-    "counter_factory", [method_counter, classmethod_counter, staticmethod_counter]
-)
+@pytest.mark.parametrize("counter_factory", counter_factories)
 @sync
 async def test_method_metadata(size, counter_factory):
     """Test cache metadata on methods"""

--- a/unittests/test_functools_lru.py
+++ b/unittests/test_functools_lru.py
@@ -25,7 +25,7 @@ async def test_method(size):
 @pytest.mark.parametrize("size", [0, 3, 10, None])
 @sync
 async def test_classmethod(size):
-    """Test wrapping a method"""
+    """Test wrapping a classmethod"""
 
     class Counter:
         _count = 0
@@ -38,6 +38,29 @@ async def test_classmethod(size):
         async def count(cls):
             cls._count += 1
             return cls._count
+
+    await _test_counting(size, Counter)
+
+
+@pytest.mark.parametrize("size", [0, 3, 10, None])
+@sync
+async def test_staticmethod(size):
+    """Test wrapping a staticmethod"""
+
+    # I'm sorry for writing this test – please don't do this at home!
+    _count = 0
+
+    class Counter:
+        def __init__(self):
+            nonlocal _count
+            _count = 0
+
+        @staticmethod
+        @a.lru_cache(maxsize=size)
+        async def count():
+            nonlocal _count
+            _count += 1
+            return _count
 
     await _test_counting(size, Counter)
 


### PR DESCRIPTION
This PR extends `lru_cache` to remove individual items from the cache.

* [x] caches are descriptors and aware of binding
* [x] individual items can be removed from the cache

Closes #81.