### PR TITLE
Graceful contextmanager cleanup

### DIFF
--- a/asyncstdlib/contextlib.py
+++ b/asyncstdlib/contextlib.py
@@ -121,7 +121,7 @@ class _AsyncGeneratorContextManager(Generic[T]):
                 # but is the closest we can get to checking the situation.
                 # See https://github.com/maxfischer2781/asyncstdlib/issues/84
                 if exc_type is GeneratorExit and result is None:
-                    return False  # type: ignore[unreachable]
+                    return False
                 raise RuntimeError("generator did not stop after throw() in __aexit__")
 
 

--- a/asyncstdlib/contextlib.py
+++ b/asyncstdlib/contextlib.py
@@ -115,7 +115,7 @@ class _AsyncGeneratorContextManager(Generic[T]):
                 # but is the closest we can get to checking the situation.
                 # See https://github.com/maxfischer2781/asyncstdlib/issues/84
                 if exc_type is GeneratorExit and result is None:
-                    return False
+                    return False  # type: ignore[unreachable]
                 raise RuntimeError("generator did not stop after throw() in __aexit__")
 
 

--- a/asyncstdlib/contextlib.py
+++ b/asyncstdlib/contextlib.py
@@ -90,7 +90,7 @@ class _AsyncGeneratorContextManager(Generic[T]):
                 raise RuntimeError("generator did not stop after __aexit__")
         else:
             try:
-                await self.gen.athrow(exc_type, exc_val, exc_tb)
+                result = await self.gen.athrow(exc_type, exc_val, exc_tb)
             except StopAsyncIteration as exc:
                 return exc is not exc_tb
             except RuntimeError as exc:
@@ -106,6 +106,16 @@ class _AsyncGeneratorContextManager(Generic[T]):
                     raise
                 return False
             else:
+                # During shutdown, the child generator might be cleaned up early.
+                # In this case,
+                # - the child will return nothing/None,
+                # - we get cleaned up via GeneratorExit as well,
+                # and we should go on with our own cleanup.
+                # This might happen if the child mishandles GeneratorExit as well,
+                # but is the closest we can get to checking the situation.
+                # See https://github.com/maxfischer2781/asyncstdlib/issues/84
+                if exc_type is GeneratorExit and result is None:
+                    return False
                 raise RuntimeError("generator did not stop after throw() in __aexit__")
 
 

--- a/unittests/test_contextlib.py
+++ b/unittests/test_contextlib.py
@@ -35,6 +35,7 @@ async def test_contextmanager():
 @sync
 async def test_contextmanager_no_yield():
     """Test that it is an error for a context to not yield"""
+
     @a.contextmanager
     async def no_yield():
         if False:
@@ -48,6 +49,7 @@ async def test_contextmanager_no_yield():
 @sync
 async def test_contextmanager_no_stop():
     """Test that it is an error for a context to yield again after stopping"""
+
     @a.contextmanager
     async def no_stop():
         yield
@@ -72,6 +74,7 @@ async def test_contextmanager_no_stop():
 @sync
 async def test_contextmanager_raise_asyncstop():
     """Test that StopAsyncIteration may propagate out of a context block"""
+
     @a.contextmanager
     async def no_raise():
         yield
@@ -117,6 +120,7 @@ async def test_contextmanager_raise_runtimeerror():
 @sync
 async def test_contextmanager_raise_same():
     """Test that outer exceptions do not shadow inner/newer ones"""
+
     @a.contextmanager
     async def reraise():
         try:
@@ -143,6 +147,7 @@ async def test_contextmanager_raise_same():
 @sync
 async def test_contextmanager_raise_generatorexit():
     """Test that shutdown via GeneratorExit is propagated"""
+
     @a.contextmanager
     async def no_op():
         yield
@@ -156,6 +161,7 @@ async def test_contextmanager_raise_generatorexit():
     with pytest.raises(GeneratorExit, match="inner"):
         context = no_op()
         async with context:
+            # simulate cleanup closing the child early
             await context.gen.aclose()
             raise GeneratorExit("inner")
 

--- a/unittests/test_contextlib.py
+++ b/unittests/test_contextlib.py
@@ -34,6 +34,7 @@ async def test_contextmanager():
 
 @sync
 async def test_contextmanager_no_yield():
+    """Test that it is an error for a context to not yield"""
     @a.contextmanager
     async def no_yield():
         if False:
@@ -46,6 +47,7 @@ async def test_contextmanager_no_yield():
 
 @sync
 async def test_contextmanager_no_stop():
+    """Test that it is an error for a context to yield again after stopping"""
     @a.contextmanager
     async def no_stop():
         yield
@@ -69,6 +71,7 @@ async def test_contextmanager_no_stop():
 
 @sync
 async def test_contextmanager_raise_asyncstop():
+    """Test that StopAsyncIteration may propagate out of a context block"""
     @a.contextmanager
     async def no_raise():
         yield
@@ -113,6 +116,7 @@ async def test_contextmanager_raise_runtimeerror():
 
 @sync
 async def test_contextmanager_raise_same():
+    """Test that outer exceptions do not shadow inner/newer ones"""
     @a.contextmanager
     async def reraise():
         try:
@@ -134,6 +138,26 @@ async def test_contextmanager_raise_same():
     with pytest.raises(KeyError, match="inside"):
         async with recreate():
             raise KeyError("outside")
+
+
+@sync
+async def test_contextmanager_raise_generatorexit():
+    """Test that shutdown via GeneratorExit is propagated"""
+    @a.contextmanager
+    async def no_op():
+        yield
+
+    with pytest.raises(GeneratorExit):
+        async with no_op():
+            raise GeneratorExit("used to tear down coroutines")
+
+    # during shutdown, generators may be killed in arbitrary order
+    # make sure we do not suppress GeneratorExit
+    with pytest.raises(GeneratorExit, match="inner"):
+        context = no_op()
+        async with context:
+            await context.gen.aclose()
+            raise GeneratorExit("inner")
 
 
 @sync


### PR DESCRIPTION
This PR adjusts `contextmanager` to handle out-of-order cleanup.

Closes #84.