### PR TITLE
Tee locking

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -18,9 +18,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
         python-version: '3.x'
     - name: Install dependencies

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -10,9 +10,9 @@ jobs:
         python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', 'pypy-3.6', 'pypy-3.7']
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/verification.yml
+++ b/.github/workflows/verification.yml
@@ -6,9 +6,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
         python-version: '3.9'
     - name: Install dependencies

--- a/asyncstdlib/itertools.py
+++ b/asyncstdlib/itertools.py
@@ -378,6 +378,9 @@ class Tee(Generic[T]):
     If the underlying iterable is concurrency safe (``anext`` may be awaited
     concurrently) the resulting iterators are concurrency safe as well. Otherwise,
     the iterators are safe if there is only ever one single "most advanced" iterator.
+    To enforce sequential use of ``anext``, provide a ``lock``
+    - e.g. an :py:class:`asyncio.Lock` instance in an :py:mod:`asyncio` application -
+    and access is automatically synchronised.
     """
 
     def __init__(

--- a/asyncstdlib/itertools.py
+++ b/asyncstdlib/itertools.py
@@ -304,7 +304,9 @@ class NoLock:
 
 async def tee_peer(
     iterator: AsyncIterator[T],
+    # the buffer specific to this peer
     buffer: Deque[T],
+    # the buffers of all peers, including our own
     peers: List[Deque[T]],
     lock: AsyncContextManager,
 ) -> AsyncGenerator[T, None]:
@@ -336,6 +338,7 @@ async def tee_peer(
             if peer_buffer is buffer:
                 peers.pop(idx)
                 break
+        # if we are the last peer, try and close the iterator
         if not peers and hasattr(iterator, "aclose"):
             await iterator.aclose()  # type: ignore
 

--- a/asyncstdlib/itertools.py
+++ b/asyncstdlib/itertools.py
@@ -296,6 +296,7 @@ async def takewhile(
 
 class NoLock:
     """Dummy lock that provides the proper interface but no protection"""
+
     async def __aenter__(self) -> None:
         pass
 
@@ -405,7 +406,17 @@ class Tee(Generic[T]):
     def __len__(self) -> int:
         return len(self._children)
 
+    @overload
     def __getitem__(self, item: int) -> AsyncIterator[T]:
+        ...
+
+    @overload
+    def __getitem__(self, item: slice) -> Tuple[AsyncIterator[T], ...]:
+        ...
+
+    def __getitem__(
+        self, item: Union[int, slice]
+    ) -> Union[AsyncIterator[T], Tuple[AsyncIterator[T], ...]]:
         return self._children[item]
 
     def __iter__(self) -> Iterator[AnyIterable[T]]:

--- a/asyncstdlib/itertools.py
+++ b/asyncstdlib/itertools.py
@@ -295,10 +295,11 @@ async def takewhile(
 
 
 class NoLock:
-    async def __aenter__(self):
+    """Dummy lock that provides the proper interface but no protection"""
+    async def __aenter__(self) -> None:
         pass
 
-    async def __aexit__(self, exc_type, exc_val, exc_tb):
+    async def __aexit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> bool:
         return False
 
 
@@ -308,7 +309,7 @@ async def tee_peer(
     buffer: Deque[T],
     # the buffers of all peers, including our own
     peers: List[Deque[T]],
-    lock: AsyncContextManager,
+    lock: AsyncContextManager[Any],
 ) -> AsyncGenerator[T, None]:
     """An individual iterator of a :py:func:`~.tee`"""
     try:
@@ -384,7 +385,7 @@ class Tee(Generic[T]):
         iterable: AnyIterable[T],
         n: int = 2,
         *,
-        lock: AsyncContextManager = NoLock(),
+        lock: AsyncContextManager[Any] = NoLock(),
     ):
         self._iterator = aiter(iterable)
         self._buffers: List[Deque[T]] = [deque() for _ in range(n)]

--- a/asyncstdlib/itertools.py
+++ b/asyncstdlib/itertools.py
@@ -385,7 +385,7 @@ class Tee(Generic[T]):
         iterable: AnyIterable[T],
         n: int = 2,
         *,
-        lock: AsyncContextManager[Any] = NoLock(),
+        lock: Optional[AsyncContextManager[Any]] = None,
     ):
         self._iterator = aiter(iterable)
         self._buffers: List[Deque[T]] = [deque() for _ in range(n)]
@@ -394,7 +394,7 @@ class Tee(Generic[T]):
                 iterator=self._iterator,
                 buffer=buffer,
                 peers=self._buffers,
-                lock=lock,
+                lock=lock if lock is not None else NoLock(),
             )
             for buffer in self._buffers
         )

--- a/asyncstdlib/itertools.py
+++ b/asyncstdlib/itertools.py
@@ -374,7 +374,7 @@ class Tee(Generic[T]):
     If ``iterable`` is an iterator and read elsewhere, ``tee`` will *not*
     provide these items. Also, ``tee`` must internally buffer each item until the
     last iterator has yielded it; if the most and least advanced iterator differ
-    by most data, using a :py:class:`list` is faster (but not lazy).
+    by most data, using a :py:class:`list` is more efficient (but not lazy).
 
     If the underlying iterable is concurrency safe (``anext`` may be awaited
     concurrently) the resulting iterators are concurrency safe as well. Otherwise,

--- a/docs/source/api/itertools.rst
+++ b/docs/source/api/itertools.rst
@@ -65,8 +65,12 @@ Iterator transforming
 Iterator splitting
 ==================
 
-.. autofunction:: tee(iterable: (async) iter T, n: int = 2)
+.. autofunction:: tee(iterable: (async) iter T, n: int = 2, [*, lock: async with Any])
     :for: :(async iter T, ...)
+
+    .. versionadded:: 3.10.5
+
+        The ``lock`` keyword parameter.
 
 .. autofunction:: pairwise(iterable: (async) iter T)
     :async-for: :(T, T)

--- a/unittests/test_itertools.py
+++ b/unittests/test_itertools.py
@@ -213,7 +213,7 @@ async def test_tee():
 
 @multi_sync
 async def test_tee_concurrent_locked():
-    """Test that properly uses a lock for synchrinisation"""
+    """Test that properly uses a lock for synchronisation"""
     items = [1, 2, 3, -5, 12, 78, -1, 111]
 
     async def iter_values():

--- a/unittests/test_itertools.py
+++ b/unittests/test_itertools.py
@@ -1,4 +1,5 @@
 import itertools
+import sys
 
 import pytest
 
@@ -232,6 +233,11 @@ async def test_tee_concurrent_locked():
     assert results == items
 
 
+# see https://github.com/python/cpython/issues/74956
+@pytest.mark.skipif(
+    sys.version_info < (3, 8),
+    reason="async generators only protect against concurrent access since 3.8",
+)
 @multi_sync
 async def test_tee_concurrent_unlocked():
     """Test that does not prevent concurrency without a lock"""

--- a/unittests/utility.py
+++ b/unittests/utility.py
@@ -87,7 +87,7 @@ class Switch:
 
 def multi_sync(test_case: Callable[..., Coroutine]):
     """
-    Mark an ``async def`` test case to be run synchronously with chicldren
+    Mark an ``async def`` test case to be run synchronously with children
 
     This emulates a primitive "event loop" which only responds
     to the :py:class:`PingPong`, :py:class:`Schedule` and :py:class:`Switch`.

--- a/unittests/utility.py
+++ b/unittests/utility.py
@@ -85,12 +85,34 @@ class Switch:
         yield self
 
 
+class Lock:
+    def __init__(self):
+        self._owned = False
+        self._waiting = []
+
+    async def __aenter__(self):
+        if self._owned:
+            # wait until it is our turn to take the lock
+            token = object()
+            self._waiting.append(token)
+            while self._owned or self._waiting[0] is not token:
+                await Switch()
+            # take the lock and remove our wait claim
+            self._owned = True
+            self._waiting.pop(0)
+        self._owned = True
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        self._owned = False
+
+
 def multi_sync(test_case: Callable[..., Coroutine]):
     """
     Mark an ``async def`` test case to be run synchronously with children
 
     This emulates a primitive "event loop" which only responds
-    to the :py:class:`PingPong`, :py:class:`Schedule` and :py:class:`Switch`.
+    to the :py:class:`PingPong`, :py:class:`Schedule`, :py:class:`Switch`
+    and :py:class:`Lock`.
     """
 
     @wraps(test_case)
@@ -103,7 +125,7 @@ def multi_sync(test_case: Callable[..., Coroutine]):
                 event = coro.send(event)
             except StopIteration as e:
                 result = e.args[0] if e.args else None
-                assert result is None
+                assert result is None, f"got '{result!r}' expected 'None'"
             else:
                 if isinstance(event, PingPong):
                     run_queue.appendleft((coro, event))


### PR DESCRIPTION
This PR adds lock support to `tee`. Major changes include:

* [x] `tee` supports and optional `lock` parameter
* [x] docs update

Closes #86.