### PR TITLE
First pass at using typing.ParamSpec to tighten types for callables. 

### DIFF
--- a/asyncstdlib/_core.py
+++ b/asyncstdlib/_core.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 from inspect import iscoroutinefunction
 from typing import (
-    Any,
     AsyncIterator,
     AsyncGenerator,
     Iterable,

--- a/asyncstdlib/_typing.py
+++ b/asyncstdlib/_typing.py
@@ -26,9 +26,9 @@ else:
         TypedDict,
     )
 
-try:
+if sys.version_info >= (3, 10):
     from typing import ParamSpec
-except ImportError:
+else:
     from typing_extensions import ParamSpec
 
 

--- a/asyncstdlib/_typing.py
+++ b/asyncstdlib/_typing.py
@@ -26,6 +26,12 @@ else:
         TypedDict,
     )
 
+try:
+    from typing import ParamSpec
+except ImportError:
+    from typing_extensions import ParamSpec
+
+
 __all__ = [
     "Protocol",
     "AsyncContextManager",
@@ -43,6 +49,7 @@ __all__ = [
     "LT",
     "ADD",
     "AnyIterable",
+    "P",
 ]
 
 # TypeVars for argument/return type
@@ -75,6 +82,9 @@ ADD = TypeVar("ADD", bound="SupportsAdd")
 class SupportsAdd(Protocol):
     def __add__(self: ADD, other: ADD) -> ADD:
         raise NotImplementedError
+
+
+P = ParamSpec("P")
 
 
 #: (async) iter T

--- a/asyncstdlib/asynctools.py
+++ b/asyncstdlib/asynctools.py
@@ -14,7 +14,7 @@ from typing import (
     Optional,
 )
 
-from ._typing import AsyncContextManager, T, T1, T2, T3, T4, T5, AnyIterable
+from ._typing import AsyncContextManager, T, T1, T2, T3, T4, T5, AnyIterable, P
 from ._core import aiter
 from .contextlib import nullcontext
 
@@ -328,12 +328,12 @@ async def apply(
 
 
 @overload
-def sync(function: Callable[..., Awaitable[T]]) -> Callable[..., Awaitable[T]]:
+def sync(function: Callable[P, Awaitable[T]]) -> Callable[P, Awaitable[T]]:
     ...
 
 
 @overload
-def sync(function: Callable[..., T]) -> Callable[..., Awaitable[T]]:
+def sync(function: Callable[P, T]) -> Callable[P, Awaitable[T]]:
     ...
 
 

--- a/asyncstdlib/builtins.py
+++ b/asyncstdlib/builtins.py
@@ -753,7 +753,7 @@ async def sorted(
             items.sort(reverse=reverse)
             return items
     else:
-        async_key = _awaitify(key)
+        async_key: Callable[[T], Awaitable[LT]] = _awaitify(key)
         keyed_items = [(await async_key(item), item) async for item in aiter(iterable)]
         keyed_items.sort(key=lambda ki: ki[0], reverse=reverse)
         return [item for key, item in keyed_items]

--- a/asyncstdlib/contextlib.py
+++ b/asyncstdlib/contextlib.py
@@ -15,7 +15,7 @@ from collections import deque
 from functools import partial
 import sys
 
-from ._typing import Protocol, AsyncContextManager, ContextManager, T, C
+from ._typing import Protocol, AsyncContextManager, ContextManager, T, C, P
 from ._core import awaitify
 from ._utility import public_module, slot_get as _slot_get
 
@@ -37,8 +37,8 @@ AC = TypeVar("AC", bound=ACloseable)
 
 
 def contextmanager(
-    func: Callable[..., AsyncGenerator[T, None]]
-) -> Callable[..., AsyncContextManager[T]]:
+    func: Callable[P, AsyncGenerator[T, None]]
+) -> Callable[P, AsyncContextManager[T]]:
     """
     Create an asynchronous context manager out of an asynchronous generator function
 

--- a/asyncstdlib/heapq.py
+++ b/asyncstdlib/heapq.py
@@ -145,7 +145,9 @@ async def merge(
     is yielded before ``b``. Use ``reverse=True`` for descending sort order.
     The ``iterables`` must be pre-sorted in the same order.
     """
-    a_key = awaitify(key) if key is not None else None
+    a_key: Callable[[Any], Awaitable[Any]] | None = (
+        awaitify(key) if key is not None else None
+    )
     # sortable iterators with (reverse) position to ensure stable sort for ties
     iter_heap: List[Tuple[_KeyIter[Any], int]] = [
         (itr, idx if not reverse else -idx)
@@ -231,7 +233,7 @@ async def _identity(x: T) -> T:
 async def nlargest(
     iterable: AsyncIterator[T],
     n: int,
-    key: Optional[Callable[[Any], Awaitable[Any]]] = None,
+    key: Optional[Callable[[T], Awaitable[LT]]] = None,
 ) -> List[T]:
     """
     Return a sorted list of the ``n`` largest elements from the (async) iterable
@@ -244,7 +246,7 @@ async def nlargest(
     The result is equivalent to ``sorted(iterable, key=key, reverse=True)[:n]``,
     but ``iterable`` is consumed lazily and items are discarded eagerly.
     """
-    a_key: Callable[[Any], Awaitable[Any]] = (
+    a_key: Callable[[T], Awaitable[LT]] = (
         awaitify(key) if key is not None else _identity  # type: ignore
     )
     return await _largest(iterable=iterable, n=n, key=a_key, reverse=False)
@@ -253,14 +255,14 @@ async def nlargest(
 async def nsmallest(
     iterable: AsyncIterator[T],
     n: int,
-    key: Optional[Callable[[Any], Awaitable[Any]]] = None,
+    key: Optional[Callable[[T], Awaitable[LT]]] = None,
 ) -> List[T]:
     """
     Return a sorted list of the ``n`` smallest elements from the (async) iterable
 
     Provides the reverse functionality to :py:func:`~.nlargest`.
     """
-    a_key: Callable[[Any], Awaitable[Any]] = (
+    a_key: Callable[[T], Awaitable[LT]] = (
         awaitify(key) if key is not None else _identity  # type: ignore
     )
     return await _largest(iterable=iterable, n=n, key=a_key, reverse=True)

--- a/asyncstdlib/itertools.py
+++ b/asyncstdlib/itertools.py
@@ -633,7 +633,7 @@ async def groupby(  # noqa: F811
     # `current_*`: buffer for key/value the current group peeked beyond its end
     current_key = current_value = nothing = object()  # type: Any
     make_key: Callable[[Any], Awaitable[Any]] = (
-        _awaitify(key) if key is not None else identity  # type: ignore
+        _awaitify(key) if key is not None else identity
     )
     async with ScopedIter(iterable) as async_iter:
         # fast-forward mode: advance to the next group


### PR DESCRIPTION
I found some of these changes to be useful. 

The following minimal example raises no errors today but gives `Argument of type "Literal['val']" cannot be assigned to parameter "val" of type "int"  "Literal['val']" is incompatible with "int" [Pyright: reportGeneralTypeIssues]` on da0d7a7a36cb449db74be9c58a42d441d8bca350 . 

```python
import asyncstdlib as a

@a.sync
def sync_inc(val: int) -> int:
    return val + 1


async def bad() -> int:
    return await sync_inc("val")
```