### PR TITLE
cached_property reacts gracefully to hasattr

### DIFF
--- a/asyncstdlib/functools.py
+++ b/asyncstdlib/functools.py
@@ -74,9 +74,7 @@ class _RepeatableCoroutine(Generic[T]):
         self.kwargs = kwargs
 
     def __await__(self) -> Generator[None, None, T]:
-        return (
-            yield from self.call(*self.args, **self.kwargs).__await__()
-        )
+        return self.call(*self.args, **self.kwargs).__await__()
 
     def __repr__(self) -> str:
         return f"<{self.__class__.__name__} object {self.call.__name__} at {id(self)}>"

--- a/asyncstdlib/functools.py
+++ b/asyncstdlib/functools.py
@@ -70,7 +70,7 @@ class _RepeatableCoroutine(Generic[T]):
         self.args = args
         self.kwargs = kwargs
 
-    def __await__(self) -> Generator[None, None, T]:
+    def __await__(self) -> Generator[Any, Any, T]:
         return self.call(*self.args, **self.kwargs).__await__()
 
     def __repr__(self) -> str:

--- a/asyncstdlib/functools.py
+++ b/asyncstdlib/functools.py
@@ -154,7 +154,7 @@ class CachedProperty(Generic[T]):
     ) -> Union["CachedProperty[T]", Awaitable[T]]:
         if instance is None:
             return self
-        return self._get_attribute(instance)
+        return _RepeatableCoroutine(self._get_attribute, instance)
 
     async def _get_attribute(self, instance: object) -> T:
         value = await self.__wrapped__(instance)

--- a/asyncstdlib/functools.py
+++ b/asyncstdlib/functools.py
@@ -64,10 +64,7 @@ class _RepeatableCoroutine(Generic[T]):
     __slots__ = ("call", "args", "kwargs")
 
     def __init__(
-            self,
-            __call: Callable[..., Coroutine[Any, Any, T]],
-            *args: Any,
-            **kwargs: Any
+        self, __call: Callable[..., Coroutine[Any, Any, T]], *args: Any, **kwargs: Any
     ):
         self.call = __call
         self.args = args

--- a/asyncstdlib/functools.py
+++ b/asyncstdlib/functools.py
@@ -6,6 +6,7 @@ from typing import (
     Generic,
     Generator,
     Optional,
+    Coroutine,
     overload,
 )
 
@@ -55,6 +56,30 @@ class AwaitableValue(Generic[T]):
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}({self.value!r})"
+
+
+class _RepeatableCoroutine(Generic[T]):
+    """Helper to ``await`` a coroutine also more or less than just once"""
+
+    __slots__ = ("call", "args", "kwargs")
+
+    def __init__(
+            self,
+            __call: Callable[..., Coroutine[Any, Any, T]],
+            *args: Any,
+            **kwargs: Any
+    ):
+        self.call = __call
+        self.args = args
+        self.kwargs = kwargs
+
+    def __await__(self) -> Generator[None, None, T]:
+        return (
+            yield from self.call(*self.args, **self.kwargs).__await__()
+        )
+
+    def __repr__(self) -> str:
+        return f"<{self.__class__.__name__} object {self.call.__name__} at {id(self)}>"
 
 
 @public_module(__name__, "cached_property")

--- a/asyncstdlib/heapq.py
+++ b/asyncstdlib/heapq.py
@@ -111,7 +111,7 @@ def merge(
 def merge(
     *iterables: AnyIterable[T],
     key: Callable[[T], Awaitable[LT]] = ...,
-    reverse: bool = ...
+    reverse: bool = ...,
 ) -> AsyncIterator[T]:
     pass
 
@@ -126,7 +126,7 @@ def merge(
 async def merge(
     *iterables: AnyIterable[Any],
     key: Optional[Callable[[Any], Any]] = None,
-    reverse: bool = False
+    reverse: bool = False,
 ) -> AsyncIterator[Any]:
     """
     Merge all pre-sorted (async) ``iterables`` into a single sorted iterator

--- a/unittests/test_itertools.py
+++ b/unittests/test_itertools.py
@@ -316,7 +316,6 @@ async def values(gby):
 @pytest.mark.parametrize("view", [keys, values])
 @sync
 async def test_groupby(iterable, key, view):
-
     for akey in (key, awaitify(key)):
         assert await view(a.groupby(iterable)) == await view(
             itertools.groupby(iterable)


### PR DESCRIPTION
This PR fixes a `RuntimeWarning` when fetching a `cached_property`, e.g. via `hasattr`. Major changes include:

* [x] Fetching a `cached_property` always returns a helper object that may be safely discarded.

Closes #99.