### PR TITLE
Make `chain` a class like the standard sync `chain`

### DIFF
--- a/asyncstdlib/itertools.py
+++ b/asyncstdlib/itertools.py
@@ -160,8 +160,8 @@ class chain(AsyncIterator[T]):
                         yield item
         self._impl = impl()
 
-    @classmethod
-    async def from_iterable(cls: type[Any], iterable: AnyIterable[AnyIterable[T]]) -> AsyncIterator[T]:
+    @staticmethod
+    async def from_iterable(iterable: AnyIterable[AnyIterable[T]]) -> AsyncIterator[T]:
         """
         Alternate constructor for :py:func:`~.chain` that lazily exhausts iterables as well
         """

--- a/asyncstdlib/itertools.py
+++ b/asyncstdlib/itertools.py
@@ -164,7 +164,8 @@ class chain(AsyncIterator[T]):
     @staticmethod
     async def from_iterable(iterable: AnyIterable[AnyIterable[T]]) -> AsyncIterator[T]:
         """
-        Alternate constructor for :py:func:`~.chain` that lazily exhausts iterables as well
+        Alternate constructor for :py:func:`~.chain` that lazily exhausts
+        iterables as well
         """
         async with ScopedIter(iterable) as iterables:
             async for sub_iterable in iterables:

--- a/asyncstdlib/itertools.py
+++ b/asyncstdlib/itertools.py
@@ -153,7 +153,7 @@ class chain(AsyncIterator[T]):
     __slots__ = ("_impl",)
 
     def __init__(self, *iterables: AnyIterable[T]):
-        async def impl():
+        async def impl() -> AsyncIterator[T]:
             for iterable in iterables:
                 async with ScopedIter(iterable) as iterator:
                     async for item in iterator:

--- a/asyncstdlib/itertools.py
+++ b/asyncstdlib/itertools.py
@@ -141,7 +141,7 @@ async def accumulate(
             yield value
 
 
-class chain(Generic[T], AsyncIterator[T]):
+class chain(AsyncIterator[T]):
     """
     An :term:`asynchronous iterator` flattening values from all ``iterables``
 

--- a/asyncstdlib/itertools.py
+++ b/asyncstdlib/itertools.py
@@ -150,7 +150,7 @@ class chain(AsyncIterator[T]):
     sequences and concatenating them, but lazily exhausts each iterable.
     """
 
-    __slots__ = "_impl",
+    __slots__ = ("_impl",)
 
     def __init__(self, *iterables: AnyIterable[T]):
         async def impl():
@@ -158,6 +158,7 @@ class chain(AsyncIterator[T]):
                 async with ScopedIter(iterable) as iterator:
                     async for item in iterator:
                         yield item
+
         self._impl = impl()
 
     @staticmethod


### PR DESCRIPTION
There are still an inconsistency between the this version and the sync version:
- The sync version is actually implemented in C, which allows their `from_iterable()` to invoke an native constructor not exposed in Python, so they can return `chain[T]`. This version simply returns a `AsyncIterator[T]` instead of `chain[T]`.

Fixes #102.
