### PR TITLE
Complete itertools.chain interface

### DIFF
--- a/asyncstdlib/itertools.py
+++ b/asyncstdlib/itertools.py
@@ -150,7 +150,7 @@ class chain(AsyncIterator[T]):
     sequences and concatenating them, but lazily exhausts each iterable.
     """
 
-    __slots__ = ("_impl",)
+    __slots__ = ("_iterator",)
 
     def __init__(self, *iterables: AnyIterable[T]):
         async def impl() -> AsyncGenerator[T, None]:
@@ -159,7 +159,7 @@ class chain(AsyncIterator[T]):
                     async for item in iterator:
                         yield item
 
-        self._impl = impl()
+        self._iterator = impl()
 
     @staticmethod
     async def from_iterable(iterable: AnyIterable[AnyIterable[T]]) -> AsyncIterator[T]:
@@ -174,10 +174,10 @@ class chain(AsyncIterator[T]):
                         yield item
 
     def __anext__(self) -> Awaitable[T]:
-        return self._impl.__anext__()
+        return self._iterator.__anext__()
 
     def aclose(self) -> Awaitable[None]:
-        return self._impl.aclose()
+        return self._iterator.aclose()
 
 
 async def compress(

--- a/asyncstdlib/itertools.py
+++ b/asyncstdlib/itertools.py
@@ -148,6 +148,10 @@ class chain(AsyncIterator[T]):
     The resulting iterator consecutively iterates over and yields all values from
     each of the ``iterables``. This is similar to converting all ``iterables`` to
     sequences and concatenating them, but lazily exhausts each iterable.
+
+    The ``chain`` assumes ownership of its ``iterables`` and closes them reliably
+    when the ``chain`` is closed. Pass the ``iterables`` via a :py:class:`tuple` to
+    ``chain.from_iterable`` to avoid closing all iterables but those already processed.
     """
 
     __slots__ = ("_iterator", "_owned_iterators")
@@ -176,7 +180,11 @@ class chain(AsyncIterator[T]):
     def from_iterable(cls, iterable: AnyIterable[AnyIterable[T]]) -> "chain[T]":
         """
         Alternate constructor for :py:func:`~.chain` that lazily exhausts
-        iterables as well
+        the ``iterable`` of iterables as well
+
+        This is suitable for chaining iterables from a lazy or infinite ``iterable``.
+        In turn, closing the ``chain`` only closes those iterables
+        already fetched from ``iterable``.
         """
         return cls(_iterables=iterable)
 

--- a/asyncstdlib/itertools.py
+++ b/asyncstdlib/itertools.py
@@ -153,14 +153,15 @@ class chain(AsyncIterator[T]):
     __slots__ = ("_iterator",)
 
     @staticmethod
-    async def impl(iterables) -> AsyncGenerator[T, None]:
-            for iterable in iterables:
+    async def _chain_iterator(iterables) -> AsyncGenerator[T, None]:
+        async with ScopedIter(iterables) as iterables_iter:
+            async for iterable in iterables_iter:
                 async with ScopedIter(iterable) as iterator:
                     async for item in iterator:
                         yield item
 
     def __init__(self, *iterables: AnyIterable[T]):
-        self._iterator = self.impl(iterables)
+        self._iterator = self._chain_iterator(iterables)
 
     @staticmethod
     async def from_iterable(iterable: AnyIterable[AnyIterable[T]]) -> AsyncIterator[T]:

--- a/asyncstdlib/itertools.py
+++ b/asyncstdlib/itertools.py
@@ -153,7 +153,7 @@ class chain(AsyncIterator[T]):
     __slots__ = ("_impl",)
 
     def __init__(self, *iterables: AnyIterable[T]):
-        async def impl() -> AsyncIterator[T]:
+        async def impl() -> AsyncGenerator[T, None]:
             for iterable in iterables:
                 async with ScopedIter(iterable) as iterator:
                     async for item in iterator:

--- a/asyncstdlib/itertools.py
+++ b/asyncstdlib/itertools.py
@@ -153,9 +153,11 @@ class chain(AsyncIterator[T]):
     __slots__ = ("_iterator",)
 
     @staticmethod
-    async def _chain_iterator(iterables) -> AsyncGenerator[T, None]:
-        async with ScopedIter(iterables) as iterables_iter:
-            async for iterable in iterables_iter:
+    async def _chain_iterator(
+        any_iterables: AnyIterable[AnyIterable[T]],
+    ) -> AsyncGenerator[T, None]:
+        async with ScopedIter(any_iterables) as iterables:
+            async for iterable in iterables:
                 async with ScopedIter(iterable) as iterator:
                     async for item in iterator:
                         yield item

--- a/asyncstdlib/itertools.py
+++ b/asyncstdlib/itertools.py
@@ -168,9 +168,7 @@ class chain(AsyncIterator[T]):
         self._iterator = self._chain_iterator(iterables or _iterables)
 
     @classmethod
-    def from_iterable(
-        cls, iterable: AnyIterable[AnyIterable[T]]
-    ) -> "chain[T]":
+    def from_iterable(cls, iterable: AnyIterable[AnyIterable[T]]) -> "chain[T]":
         """
         Alternate constructor for :py:func:`~.chain` that lazily exhausts
         iterables as well

--- a/asyncstdlib/itertools.py
+++ b/asyncstdlib/itertools.py
@@ -170,7 +170,7 @@ class chain(AsyncIterator[T]):
     @classmethod
     def from_iterable(
         cls, iterable: AnyIterable[AnyIterable[T]]
-    ) -> AsyncIterator[T]:
+    ) -> "chain[T]":
         """
         Alternate constructor for :py:func:`~.chain` that lazily exhausts
         iterables as well

--- a/asyncstdlib/itertools.py
+++ b/asyncstdlib/itertools.py
@@ -152,14 +152,15 @@ class chain(AsyncIterator[T]):
 
     __slots__ = ("_iterator",)
 
-    def __init__(self, *iterables: AnyIterable[T]):
-        async def impl() -> AsyncGenerator[T, None]:
+    @staticmethod
+    async def impl(iterables) -> AsyncGenerator[T, None]:
             for iterable in iterables:
                 async with ScopedIter(iterable) as iterator:
                     async for item in iterator:
                         yield item
 
-        self._iterator = impl()
+    def __init__(self, *iterables: AnyIterable[T]):
+        self._iterator = self.impl(iterables)
 
     @staticmethod
     async def from_iterable(iterable: AnyIterable[AnyIterable[T]]) -> AsyncIterator[T]:

--- a/asyncstdlib/itertools.py
+++ b/asyncstdlib/itertools.py
@@ -176,6 +176,9 @@ class chain(AsyncIterator[T]):
     def __anext__(self) -> Awaitable[T]:
         return self._impl.__anext__()
 
+    def aclose(self) -> Awaitable[None]:
+        return self._impl.aclose()
+
 
 async def compress(
     data: AnyIterable[T], selectors: AnyIterable[bool]

--- a/asyncstdlib/itertools.py
+++ b/asyncstdlib/itertools.py
@@ -162,20 +162,20 @@ class chain(AsyncIterator[T]):
                     async for item in iterator:
                         yield item
 
-    def __init__(self, *iterables: AnyIterable[T]):
-        self._iterator = self._chain_iterator(iterables)
+    def __init__(
+        self, *iterables: AnyIterable[T], _iterables: AnyIterable[AnyIterable[T]] = ()
+    ):
+        self._iterator = self._chain_iterator(iterables or _iterables)
 
-    @staticmethod
-    async def from_iterable(iterable: AnyIterable[AnyIterable[T]]) -> AsyncIterator[T]:
+    @classmethod
+    def from_iterable(
+        cls, iterable: AnyIterable[AnyIterable[T]]
+    ) -> AsyncIterator[T]:
         """
         Alternate constructor for :py:func:`~.chain` that lazily exhausts
         iterables as well
         """
-        async with ScopedIter(iterable) as iterables:
-            async for sub_iterable in iterables:
-                async with ScopedIter(sub_iterable) as iterator:
-                    async for item in iterator:
-                        yield item
+        return cls(_iterables=iterable)
 
     def __anext__(self) -> Awaitable[T]:
         return self._iterator.__anext__()

--- a/unittests/test_itertools.py
+++ b/unittests/test_itertools.py
@@ -134,6 +134,8 @@ async def test_chain_close_partial(iterables, chain_type, must_close):
     assert await a.anext(chain) == next(itertools.chain(*iterables))
     await chain.aclose()
     assert all(iterable.closed == must_close for iterable in closeable_iterables[1:])
+    # closed chain must remain closed regardless of iterators
+    assert await a.anext(chain, "sentinel") == "sentinel"
 
 
 compress_cases = [

--- a/unittests/test_itertools.py
+++ b/unittests/test_itertools.py
@@ -87,6 +87,54 @@ async def test_chain(iterables):
         )
 
 
+class ACloseFacade:
+    """Wrapper to check if an iterator has been closed"""
+
+    def __init__(self, iterable):
+        self.closed = False
+        self.__wrapped__ = iterable
+        self._iterator = a.iter(iterable)
+
+    async def __anext__(self):
+        if self.closed:
+            raise StopAsyncIteration()
+        return await self._iterator.__anext__()
+
+    def __aiter__(self):
+        return self
+
+    async def aclose(self):
+        if hasattr(self._iterator, "aclose"):
+            await self._iterator.aclose()
+        self.closed = True
+
+
+@pytest.mark.parametrize("iterables", chains)
+@sync
+async def test_chain_close_auto(iterables):
+    """Test that `chain` closes exhausted iterators"""
+    closeable_iterables = [ACloseFacade(iterable) for iterable in iterables]
+    assert await a.list(a.chain(*closeable_iterables)) == list(
+        itertools.chain(*iterables)
+    )
+    assert all(iterable.closed for iterable in closeable_iterables)
+
+
+# insert a known filled iterable since chain closes all that are exhausted
+@pytest.mark.parametrize("iterables", [([1], *chain) for chain in chains])
+@pytest.mark.parametrize("chain_type, must_close", [
+    (lambda iterators: a.chain(*iterators), True), (a.chain.from_iterable, False)
+])
+@sync
+async def test_chain_close_partial(iterables, chain_type, must_close):
+    """Test that `chain` closes owned iterators"""
+    closeable_iterables = [ACloseFacade(iterable) for iterable in iterables]
+    chain = chain_type(closeable_iterables)
+    assert await a.anext(chain) == next(itertools.chain(*iterables))
+    await chain.aclose()
+    assert all(iterable.closed == must_close for iterable in closeable_iterables[1:])
+
+
 compress_cases = [
     (range(20), [idx % 2 for idx in range(20)]),
     ([1] * 5, [True, True, False, True, True]),

--- a/unittests/test_itertools.py
+++ b/unittests/test_itertools.py
@@ -122,9 +122,10 @@ async def test_chain_close_auto(iterables):
 
 # insert a known filled iterable since chain closes all that are exhausted
 @pytest.mark.parametrize("iterables", [([1], *chain) for chain in chains])
-@pytest.mark.parametrize("chain_type, must_close", [
-    (lambda iterators: a.chain(*iterators), True), (a.chain.from_iterable, False)
-])
+@pytest.mark.parametrize(
+    "chain_type, must_close",
+    [(lambda iterators: a.chain(*iterators), True), (a.chain.from_iterable, False)],
+)
 @sync
 async def test_chain_close_partial(iterables, chain_type, must_close):
     """Test that `chain` closes owned iterators"""


### PR DESCRIPTION
This PR adjusts the `itertools.chain` class to provide similar functionality as before. Major changes include:

* [x] Added an `aclose` method (closes #107)
* [x] Consistent implementation for `chain` and `chain.from_iterable`
* [x] General cleanup and typing
* [x] Defined ownership rules
* [x] Unittests
