### PR TITLE
Fix stable sort in heapq.merge: python uses both __eq__ and __lt__ to…

### DIFF
--- a/asyncstdlib/heapq.py
+++ b/asyncstdlib/heapq.py
@@ -99,6 +99,9 @@ class _KeyIter(Generic[LT]):
     def __lt__(self, other: "_KeyIter[LT]") -> bool:
         return self.reverse ^ (self.head_key < other.head_key)
 
+    def __eq__(self, other: "_KeyIter[LT]") -> bool:
+        return not (self.head_key < other.head_key or other.head_key < self.head_key)
+
 
 @overload
 def merge(

--- a/asyncstdlib/heapq.py
+++ b/asyncstdlib/heapq.py
@@ -99,7 +99,7 @@ class _KeyIter(Generic[LT]):
     def __lt__(self, other: "_KeyIter[LT]") -> bool:
         return self.reverse ^ (self.head_key < other.head_key)
 
-    def __eq__(self, other: "_KeyIter[LT]") -> bool:
+    def __eq__(self, other: "_KeyIter[LT]") -> bool:  # type: ignore[override]
         return not (self.head_key < other.head_key or other.head_key < self.head_key)
 
 


### PR DESCRIPTION
… compare tuples.

resolves #111