### PR TITLE
Support Py3.12

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -11,7 +11,10 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', 'pypy-3.6', 'pypy-3.7']
+        python-version: [
+          '3.6', '3.7', '3.8', '3.9', '3.10', '3.11', '3.12',
+          'pypy-3.6', 'pypy-3.8', 'pypy-3.10'
+        ]
 
     steps:
     - uses: actions/checkout@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,8 @@ classifiers = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
 ]
 license = {"file" = "LICENSE"}
 keywords = ["async", "enumerate", "itertools", "builtins", "functools", "contextlib"]


### PR DESCRIPTION
This PR extends metadata and automation to cover Python 3.12. There are no functional changes.

----

This is separate from Python 3.12 feature of coverage in #110.