### PR TITLE
Add itertools batched

### DIFF
--- a/asyncstdlib/__init__.py
+++ b/asyncstdlib/__init__.py
@@ -21,6 +21,7 @@ from .functools import reduce, lru_cache, cache, cached_property
 from .contextlib import closing, contextmanager, nullcontext, ExitStack
 from .itertools import (
     accumulate,
+    batched,
     cycle,
     chain,
     compress,
@@ -68,6 +69,7 @@ __all__ = [
     "ExitStack",
     # itertools
     "accumulate",
+    "batched",
     "cycle",
     "chain",
     "compress",

--- a/docs/source/api/itertools.rst
+++ b/docs/source/api/itertools.rst
@@ -80,6 +80,11 @@ Iterator splitting
 
     .. versionadded:: 3.10.0
 
+.. autofunction:: batched(iterable: (async) iter T, n: int)
+    :async-for: :T
+
+    .. versionadded:: 3.11.0
+
 .. py:function:: groupby(iterable: (async) iter T)
     :async-for: :(T, async iter T)
     :noindex:

--- a/unittests/test_itertools.py
+++ b/unittests/test_itertools.py
@@ -57,6 +57,28 @@ async def test_accumulate_misuse():
         assert await a.list(a.accumulate([]))
 
 
+batched_cases = [
+    (range(10), 2, [(0, 1), (2, 3), (4, 5), (6, 7), (8, 9)]),
+    (range(10), 3, [(0, 1, 2), (3, 4, 5), (6, 7, 8), (9,)]),
+    (range(10), 17, [tuple(range(10))]),
+    ([], 2, []),
+]
+
+
+@pytest.mark.parametrize("iterable, length, result", batched_cases)
+@sync
+async def test_batched(iterable, length, result):
+    assert await a.list(a.batched(iterable, length)) == result
+    assert await a.list(a.batched(asyncify(iterable), length)) == result
+
+
+@sync
+@pytest.mark.parametrize("length", (0, -1))
+async def test_batched_invalid(length):
+    with pytest.raises(ValueError):
+        await a.list(a.batched(range(10), length))
+
+
 @sync
 async def test_cycle():
     async for _ in a.cycle([]):


### PR DESCRIPTION
Add async version of `itertools.batched`.

Closes #110.