### PR TITLE
Drop duplicated from _core

### DIFF
--- a/asyncstdlib/builtins.py
+++ b/asyncstdlib/builtins.py
@@ -18,10 +18,10 @@ import builtins as _sync_builtins
 from ._typing import T, T1, T2, T3, T4, T5, R, HK, LT, ADD, AnyIterable
 from ._core import (
     aiter,
-    ScopedIter,
     awaitify as _awaitify,
     Sentinel,
 )
+from .asynctools import scoped_iter
 
 
 __ANEXT_DEFAULT = Sentinel("<no default>")
@@ -122,7 +122,7 @@ async def all(iterable: AnyIterable[T]) -> bool:
     """
     Return :py:data:`True` if none of the elements of the (async) ``iterable`` are false
     """
-    async with ScopedIter(iterable) as item_iter:
+    async with scoped_iter(iterable) as item_iter:
         async for element in item_iter:
             if not element:
                 return False
@@ -133,7 +133,7 @@ async def any(iterable: AnyIterable[T]) -> bool:
     """
     Return :py:data:`False` if none of the elements of the (async) ``iterable`` are true
     """
-    async with ScopedIter(iterable) as item_iter:
+    async with scoped_iter(iterable) as item_iter:
         async for element in item_iter:
             if element:
                 return True
@@ -439,7 +439,7 @@ async def map(
     Multiple ``iterable`` may be mixed regular and async iterables.
     """
     function = _awaitify(function)
-    async with ScopedIter(zip(*iterable)) as args_iter:
+    async with scoped_iter(zip(*iterable)) as args_iter:
         async for args in args_iter:
             result = function(*args)
             yield await result
@@ -559,7 +559,7 @@ async def _min_max(
 
     :param invert: compute ``max`` if ``True`` and ``min`` otherwise
     """
-    async with ScopedIter(iterable) as item_iter:
+    async with scoped_iter(iterable) as item_iter:
         best = await anext(item_iter, default=default)
         # this implies that item_iter is empty and default is __MIN_MAX_DEFAULT
         if best is __MIN_MAX_DEFAULT:  # type: ignore
@@ -593,7 +593,7 @@ async def filter(
     The ``function`` may be a regular or async callable.
     The ``iterable`` may be a regular or async iterable.
     """
-    async with ScopedIter(iterable) as item_iter:
+    async with scoped_iter(iterable) as item_iter:
         if function is None:
             async for item in item_iter:
                 if item:
@@ -616,7 +616,7 @@ async def enumerate(
     The ``iterable`` may be a regular or async iterable.
     """
     count = start
-    async with ScopedIter(iterable) as item_iter:
+    async with scoped_iter(iterable) as item_iter:
         async for item in item_iter:
             yield count, item
             count += 1

--- a/asyncstdlib/functools.py
+++ b/asyncstdlib/functools.py
@@ -11,7 +11,8 @@ from typing import (
 )
 
 from ._typing import T, AC, AnyIterable
-from ._core import ScopedIter, awaitify as _awaitify, Sentinel
+from ._core import awaitify as _awaitify, Sentinel
+from .asynctools import scoped_iter
 from .builtins import anext
 from ._utility import public_module
 
@@ -179,7 +180,7 @@ async def reduce(
     and ``iterable`` contains exactly one item, it is returned without
     calling ``function``.
     """
-    async with ScopedIter(iterable) as item_iter:
+    async with scoped_iter(iterable) as item_iter:
         try:
             value = (
                 initial if initial is not __REDUCE_SENTINEL else await anext(item_iter)

--- a/asyncstdlib/heapq.py
+++ b/asyncstdlib/heapq.py
@@ -11,8 +11,9 @@ from typing import (
 )
 import heapq as _heapq
 
+from .asynctools import borrow, scoped_iter
 from .builtins import enumerate as a_enumerate, zip as a_zip
-from ._core import aiter, awaitify, ScopedIter, borrow
+from ._core import aiter, awaitify
 from ._typing import AnyIterable, LT, T, SupportsLT
 
 
@@ -205,7 +206,7 @@ async def _largest(
     ordered: Callable[[SupportsLT], SupportsLT] = (
         ReverseLT if reverse else lambda x: x  # type: ignore
     )
-    async with ScopedIter(iterable) as iterator:
+    async with scoped_iter(iterable) as iterator:
         # assign an ordering to items to solve ties
         order_sign = -1 if reverse else 1
         n_heap = [

--- a/unittests/test_helpers.py
+++ b/unittests/test_helpers.py
@@ -1,7 +1,4 @@
 from asyncstdlib import _utility
-from asyncstdlib import _core
-
-from .utility import sync
 
 
 def test_slot_get():
@@ -20,24 +17,3 @@ def test_slot_get():
     instance.__neg__ = lambda self: 12
     assert _utility.slot_get(instance, "data") is data
     assert _utility.slot_get(instance, "__neg__")() == neg
-
-
-@sync
-async def test_scoped_iter_graceful():
-    class AIterator:
-        async def __anext__(self):
-            return 1
-
-        def __aiter__(self):
-            return self
-
-    class AIterable:
-        def __aiter__(self):
-            return AIterator()
-
-    async_iterable = AIterable()
-    async with _core.ScopedIter(async_iterable) as async_iterator:
-        # test that no error from calling the missing `aclose` is thrown
-        assert async_iterator is not async_iterable
-        assert (await async_iterator.__anext__()) == 1
-    assert (await async_iterator.__anext__()) == 1


### PR DESCRIPTION
Drop `ScopedIter` and `borrow` from `_core` in favor of those defined in `asynctools`.

In #115 I discovered `ScopedIter` and `scoped_iter` behave diferently (`batched` didn't work properly with `ScopedIter`), but dropping the former seems to be better idea than trying to fix it.