### PR TITLE
Fix ReadTheDocs configuration

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -6,7 +6,6 @@ build:
     python: "3.11"
 
 python:
-  version: 3
   install:
     - method: pip
       path: .

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,5 +1,10 @@
 version: 2
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
 python:
   version: 3
   install:


### PR DESCRIPTION
This PR adjusts the RTD configuration to fix [failing docs builds](https://readthedocs.org/projects/asyncstdlib/builds/22944573/) in accordance with the currently expected format. See [test builds](https://readthedocs.org/projects/asyncstdlib/builds/) for status.