### PR TITLE
Deprecate Py3.6 and Py3.7

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -20,3 +20,4 @@ exclude_lines =
     if __name__ == '__main__'
     @overload
     if TYPE_CHECKING
+    ...

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -18,9 +18,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: '3.x'
     - name: Install dependencies

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -17,9 +17,9 @@ jobs:
         ]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -8,12 +8,12 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: [
-          '3.6', '3.7', '3.8', '3.9', '3.10', '3.11', '3.12',
-          'pypy-3.6', 'pypy-3.8', 'pypy-3.10'
+          '3.8', '3.9', '3.10', '3.11', '3.12',
+          'pypy-3.8', 'pypy-3.10'
         ]
 
     steps:

--- a/.github/workflows/verification.yml
+++ b/.github/workflows/verification.yml
@@ -10,11 +10,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
-        python-version: '3.9'
+        python-version: '3.x'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/asyncstdlib/_core.py
+++ b/asyncstdlib/_core.py
@@ -1,3 +1,12 @@
+"""
+Internal helpers to safely build async abstractions
+
+While some of these helpers have public siblings
+(e.g. :py:class:`~.ScopedIter` and :py:func:`~.asynctools.scoped_iter`)
+they are purposely kept separate.
+Any helpers in this module are *not* bound to maintaining a public interface,
+and offer less convenience to save on overhead.
+"""
 from inspect import iscoroutinefunction
 from typing import (
     Any,
@@ -55,7 +64,12 @@ async def _aiter_sync(iterable: Iterable[T]) -> AsyncIterator[T]:
 
 
 class ScopedIter(Generic[T]):
-    """Context manager that provides and cleans up an iterator for an iterable"""
+    """
+    Context manager that provides and cleans up an iterator for an iterable
+
+    Note that unlike :py:func:`~.asynctools.scoped_iter`, this helper does
+    *not* borrow the iterator automatically. Use :py:func:`~.borrow` if needed.
+    """
 
     __slots__ = ("_iterator",)
 

--- a/asyncstdlib/_core.py
+++ b/asyncstdlib/_core.py
@@ -79,10 +79,9 @@ class ScopedIter(Generic[T]):
             await aclose
 
 
-async def borrow(iterator: AsyncIterator[T]) -> AsyncGenerator[T, None]:
+def borrow(iterator: AsyncIterator[T]) -> AsyncGenerator[T, None]:
     """Borrow an async iterator for iteration, preventing it from being closed"""
-    async for item in iterator:
-        yield item
+    return (item async for item in iterator)
 
 
 def awaitify(

--- a/asyncstdlib/_core.py
+++ b/asyncstdlib/_core.py
@@ -104,8 +104,7 @@ class Awaitify(Generic[T]):
         self._async_call: Optional[Callable[..., Awaitable[T]]] = None
 
     def __call__(self, *args: Any, **kwargs: Any) -> Awaitable[T]:
-        async_call = self._async_call
-        if async_call is None:
+        if (async_call := self._async_call) is None:
             value = self.__wrapped__(*args, **kwargs)
             if isinstance(value, Awaitable):
                 self._async_call = self.__wrapped__  # type: ignore

--- a/asyncstdlib/_lrucache.py
+++ b/asyncstdlib/_lrucache.py
@@ -76,15 +76,18 @@ class LRUAsyncCallable(Protocol[AC]):
 
     def cache_parameters(self) -> CacheParameters:
         """Get the parameters of the cache"""
+        ...
 
     def cache_info(self) -> CacheInfo:
         """
         Get the current performance and boundary of the cache
         as a :py:class:`~typing.NamedTuple`
         """
+        ...
 
     def cache_clear(self) -> None:
         """Evict all call argument patterns and their results from the cache"""
+        ...
 
     def cache_discard(self, *args: Any, **kwargs: Any) -> None:
         """
@@ -95,9 +98,11 @@ class LRUAsyncCallable(Protocol[AC]):
         the descriptor must support wrapping descriptors for this method
         to detect implicit arguments such as ``self``.
         """
+        # Maintainers note:
         # "support wrapping descriptors" means that the wrapping descriptor has to use
         # the cache as a descriptor as well, i.e. invoke its ``__get__`` method instead
         # of just passing in `self`/`cls`/... directly.
+        ...
 
 
 class LRUAsyncBoundCallable(LRUAsyncCallable[AC]):

--- a/asyncstdlib/_lrucache.py
+++ b/asyncstdlib/_lrucache.py
@@ -217,7 +217,8 @@ def lru_cache(
     elif callable(maxsize):
         # used as function decorator, first arg is the function to be wrapped
         fast_wrapper = CachedLRUAsyncCallable(cast(AC, maxsize), typed, 128)
-        return update_wrapper(fast_wrapper, maxsize)
+        update_wrapper(fast_wrapper, maxsize)
+        return fast_wrapper
     elif maxsize is not None:
         raise TypeError(
             "first argument to 'lru_cache' must be an int, a callable or None"
@@ -232,7 +233,8 @@ def lru_cache(
             wrapper = UncachedLRUAsyncCallable(function, typed)
         else:
             wrapper = CachedLRUAsyncCallable(function, typed, maxsize)
-        return update_wrapper(wrapper, function)
+        update_wrapper(wrapper, function)
+        return wrapper
 
     return lru_decorator
 

--- a/asyncstdlib/_lrucache.py
+++ b/asyncstdlib/_lrucache.py
@@ -308,11 +308,11 @@ class UncachedLRUAsyncCallable(LRUAsyncCallable[AC]):
     __get__ = cache__get
 
     def __init__(self, call: AC, typed: bool):
-        self.__wrapped__ = call
+        self.__wrapped__ = call  # type: ignore[reportIncompatibleMethodOverride]
         self.__misses = 0
         self.__typed = typed
 
-    async def __call__(self, *args, **kwargs):  # type: ignore
+    async def __call__(self, *args: Any, **kwargs: Any) -> Any:  # type: ignore[reportIncompatibleVariableOverride]
         self.__misses += 1
         return await self.__wrapped__(*args, **kwargs)
 
@@ -346,13 +346,13 @@ class MemoizedLRUAsyncCallable(LRUAsyncCallable[AC]):
     __get__ = cache__get
 
     def __init__(self, call: AC, typed: bool):
-        self.__wrapped__ = call
+        self.__wrapped__ = call  # type: ignore[reportIncompatibleMethodOverride]
         self.__hits = 0
         self.__misses = 0
         self.__typed = typed
         self.__cache: Dict[Union[CallKey, int, str], Any] = {}
 
-    async def __call__(self, *args, **kwargs):  # type: ignore
+    async def __call__(self, *args: Any, **kwargs: Any) -> Any:  # type: ignore[reportIncompatibleVariableOverride]
         key = CallKey.from_call(args, kwargs, typed=self.__typed)
         try:
             result = self.__cache[key]
@@ -401,14 +401,14 @@ class CachedLRUAsyncCallable(LRUAsyncCallable[AC]):
     __get__ = cache__get
 
     def __init__(self, call: AC, typed: bool, maxsize: int):
-        self.__wrapped__ = call
+        self.__wrapped__ = call  # type: ignore[reportIncompatibleMethodOverride]
         self.__hits = 0
         self.__misses = 0
         self.__typed = typed
         self.__maxsize = maxsize
         self.__cache: OrderedDict[Union[int, str, CallKey], Any] = OrderedDict()
 
-    async def __call__(self, *args, **kwargs):  # type: ignore
+    async def __call__(self, *args: Any, **kwargs: Any) -> Any:  # type: ignore[reportIncompatibleVariableOverride]
         key = CallKey.from_call(args, kwargs, typed=self.__typed)
         try:
             result = self.__cache[key]

--- a/asyncstdlib/_typing.py
+++ b/asyncstdlib/_typing.py
@@ -4,7 +4,6 @@ Helper module to simplify version specific typing imports
 This module is for internal use only. Do *not* put any new
 "async typing" definitions here.
 """
-import sys
 from typing import (
     TypeVar,
     Hashable,
@@ -16,15 +15,7 @@ from typing import (
     Awaitable,
 )
 
-if sys.version_info >= (3, 8):
-    from typing import Protocol, AsyncContextManager, ContextManager, TypedDict
-else:
-    from typing_extensions import (
-        Protocol,
-        AsyncContextManager,
-        ContextManager,
-        TypedDict,
-    )
+from typing import Protocol, AsyncContextManager, ContextManager, TypedDict
 
 __all__ = [
     "Protocol",

--- a/asyncstdlib/_utility.py
+++ b/asyncstdlib/_utility.py
@@ -29,21 +29,3 @@ def public_module(
         return thing
 
     return decorator
-
-
-def slot_get(instance: object, name: str) -> Any:
-    """
-    Emulate ``instance.name`` using slot lookup as used for special methods
-
-    This invokes the descriptor protocol, i.e. it calls the attribute's
-    ``__get__`` if available.
-    """
-
-    owner = type(instance)
-    attribute = getattr(owner, name)
-    try:
-        descriptor_get = attribute.__get__
-    except AttributeError:
-        return attribute
-    else:
-        return descriptor_get(instance, owner)

--- a/asyncstdlib/_utility.py
+++ b/asyncstdlib/_utility.py
@@ -1,4 +1,4 @@
-from typing import TypeVar, Any, Optional, Callable
+from typing import TypeVar, Optional, Callable
 
 from ._typing import Protocol
 

--- a/asyncstdlib/asynctools.py
+++ b/asyncstdlib/asynctools.py
@@ -42,7 +42,7 @@ class _BorrowedAsyncIterator(AsyncGenerator[T, S]):
         # Create an actual async generator wrapper that we can close. Otherwise,
         # if we pass on the original iterator methods we cannot disable them if
         # anyone has a reference to them.
-        self._wrapper: AsyncGenerator[T, S] = self._wrapped_iterator(iterator)
+        self._wrapper: AsyncGenerator[T, None] = (item async for item in iterator)
         # Forward all async iterator/generator methods but __aiter__ and aclose:
         # An async *iterator* (e.g. `async def: yield`) must return
         # itself from __aiter__. If we do not shadow this then
@@ -52,16 +52,6 @@ class _BorrowedAsyncIterator(AsyncGenerator[T, S]):
             self.asend = iterator.asend
         if hasattr(iterator, "athrow"):
             self.athrow = iterator.athrow
-
-    # Py3.6 compatibility
-    # Use ``(item async for item in iterator)`` inside
-    # ``__init__`` when no longer needed.
-    @staticmethod
-    async def _wrapped_iterator(
-        iterator: Union[AsyncIterator[T], AsyncGenerator[T, S]]
-    ) -> AsyncGenerator[T, S]:
-        async for item in iterator:
-            yield item
 
     def __aiter__(self) -> AsyncGenerator[T, S]:
         return self

--- a/asyncstdlib/asynctools.py
+++ b/asyncstdlib/asynctools.py
@@ -49,9 +49,13 @@ class _BorrowedAsyncIterator(AsyncGenerator[T, S]):
         # running aiter(self).aclose closes the underlying iterator.
         self.__anext__ = self._wrapper.__anext__  # type: ignore
         if hasattr(iterator, "asend"):
-            self.asend = iterator.asend
+            self.asend = (
+                iterator.asend  # pyright: ignore[reportUnknownMemberType,reportGeneralTypeIssues]
+            )
         if hasattr(iterator, "athrow"):
-            self.athrow = iterator.athrow
+            self.athrow = (
+                iterator.athrow  # pyright: ignore[reportUnknownMemberType,reportGeneralTypeIssues]
+            )
 
     def __aiter__(self) -> AsyncGenerator[T, S]:
         return self
@@ -411,7 +415,11 @@ async def any_iter(
     iterable = __iter if not isinstance(__iter, Awaitable) else await __iter
     if isinstance(iterable, AsyncIterable):
         async for item in iterable:
-            yield item if not isinstance(item, Awaitable) else await item
+            yield item if not isinstance(
+                item, Awaitable
+            ) else await item  # pyright: ignore[reportGeneralTypeIssues]
     else:
         for item in iterable:
-            yield item if not isinstance(item, Awaitable) else await item
+            yield item if not isinstance(
+                item, Awaitable
+            ) else await item  # pyright: ignore[reportGeneralTypeIssues]

--- a/asyncstdlib/asynctools.py
+++ b/asyncstdlib/asynctools.py
@@ -114,7 +114,7 @@ class _ScopedAsyncIteratorContext(AsyncContextManager[AsyncIterator[T]]):
         return f"<{self.__class__.__name__} of {self._iterator!r} at 0x{(id(self)):x}>"
 
 
-def borrow(iterator: AsyncIterator[T]) -> AsyncIterator[T]:
+def borrow(iterator: AsyncIterator[T], /) -> AsyncIterator[T]:
     """
     Borrow an async iterator, preventing to ``aclose`` it
 
@@ -140,7 +140,7 @@ def borrow(iterator: AsyncIterator[T]) -> AsyncIterator[T]:
     return _BorrowedAsyncIterator(iterator)
 
 
-def scoped_iter(iterable: AnyIterable[T]) -> AsyncContextManager[AsyncIterator[T]]:
+def scoped_iter(iterable: AnyIterable[T], /) -> AsyncContextManager[AsyncIterator[T]]:
     """
     Context manager that provides an async iterator for an (async) ``iterable``
 
@@ -182,7 +182,7 @@ def scoped_iter(iterable: AnyIterable[T]) -> AsyncContextManager[AsyncIterator[T
     return _ScopedAsyncIteratorContext(iterator)
 
 
-async def await_each(awaitables: Iterable[Awaitable[T]]) -> AsyncIterable[T]:
+async def await_each(awaitables: Iterable[Awaitable[T]], /) -> AsyncIterable[T]:
     """
     Iterate through ``awaitables`` and await each item
 
@@ -217,6 +217,7 @@ async def await_each(awaitables: Iterable[Awaitable[T]]) -> AsyncIterable[T]:
 async def apply(
     __func: Callable[[T1], T],
     __arg1: Awaitable[T1],
+    /,
 ) -> T:
     ...
 
@@ -226,6 +227,7 @@ async def apply(
     __func: Callable[[T1, T2], T],
     __arg1: Awaitable[T1],
     __arg2: Awaitable[T2],
+    /,
 ) -> T:
     ...
 
@@ -236,6 +238,7 @@ async def apply(
     __arg1: Awaitable[T1],
     __arg2: Awaitable[T2],
     __arg3: Awaitable[T3],
+    /,
 ) -> T:
     ...
 
@@ -247,6 +250,7 @@ async def apply(
     __arg2: Awaitable[T2],
     __arg3: Awaitable[T3],
     __arg4: Awaitable[T4],
+    /,
 ) -> T:
     ...
 
@@ -259,6 +263,7 @@ async def apply(
     __arg3: Awaitable[T3],
     __arg4: Awaitable[T4],
     __arg5: Awaitable[T5],
+    /,
 ) -> T:
     ...
 
@@ -266,27 +271,15 @@ async def apply(
 @overload
 async def apply(
     __func: Callable[..., T],
-    __arg1: Awaitable[Any],
-    __arg2: Awaitable[Any],
-    __arg3: Awaitable[Any],
-    __arg4: Awaitable[Any],
-    __arg5: Awaitable[Any],
+    /,
     *args: Awaitable[Any],
     **kwargs: Awaitable[Any],
 ) -> T:
     ...
 
 
-@overload
 async def apply(
-    __func: Callable[..., T],
-    **kwargs: Awaitable[Any],
-) -> T:
-    ...
-
-
-async def apply(
-    __func: Callable[..., T], *args: Awaitable[Any], **kwargs: Awaitable[Any]
+    __func: Callable[..., T], /, *args: Awaitable[Any], **kwargs: Awaitable[Any]
 ) -> T:
     """
     Await the arguments and keyword arguments and then apply ``func`` on them
@@ -316,16 +309,16 @@ async def apply(
 
 
 @overload
-def sync(function: Callable[..., Awaitable[T]]) -> Callable[..., Awaitable[T]]:
+def sync(function: Callable[..., Awaitable[T]], /) -> Callable[..., Awaitable[T]]:
     ...
 
 
 @overload
-def sync(function: Callable[..., T]) -> Callable[..., Awaitable[T]]:
+def sync(function: Callable[..., T], /) -> Callable[..., Awaitable[T]]:
     ...
 
 
-def sync(function: Callable[..., Any]) -> Callable[..., Any]:
+def sync(function: Callable[..., Any], /) -> Callable[..., Any]:
     r"""
     Wraps a callable to ensure its result can be ``await``\ ed
 
@@ -381,7 +374,8 @@ async def any_iter(
         Awaitable[AnyIterable[T]],
         AnyIterable[Awaitable[T]],
         AnyIterable[T],
-    ]
+    ],
+    /,
 ) -> AsyncIterator[T]:
     """
     Provide an async iterator for various forms of "asynchronous iterable"

--- a/asyncstdlib/asynctools.py
+++ b/asyncstdlib/asynctools.py
@@ -172,15 +172,14 @@ def scoped_iter(iterable: AnyIterable[T]) -> AsyncContextManager[AsyncIterator[T
     closing the underlying iterator in favour of the outermost scope. This allows
     passing the scoped iterator to other functions that use :py:func:`scoped_iter`.
     """
-    # The iterable has already been borrowed.
-    # Do not unwrap it to preserve method forwarding.
-    if isinstance(iterable, (_BorrowedAsyncIterator, _ScopedAsyncIterator)):
-        return _ScopedAsyncIteratorContext(iterable)
     iterator = aiter(iterable)
     # The iterable cannot be closed.
     # We do not need to take care of it.
     if not hasattr(iterator, "aclose"):
         return nullcontext(iterator)
+    # `iterator` might be already borrowed. We must not special-case this as:
+    # - we cannot unwrap the underlying iterator, as this would give us longer access
+    # - we still must create a separate scope with its own lifetime
     return _ScopedAsyncIteratorContext(iterator)
 
 

--- a/asyncstdlib/asynctools.py
+++ b/asyncstdlib/asynctools.py
@@ -102,8 +102,8 @@ class _ScopedAsyncIteratorContext(AsyncContextManager[AsyncIterator[T]]):
     async def __aenter__(self) -> AsyncIterator[T]:
         if self._borrowed_iter is not None:
             raise RuntimeError("scoped_iter is not re-entrant")
-        borrowed_iter = self._borrowed_iter = _ScopedAsyncIterator(self._iterator)
-        return borrowed_iter
+        self._borrowed_iter = _ScopedAsyncIterator(self._iterator)
+        return self._borrowed_iter
 
     async def __aexit__(self, *args: Any) -> bool:
         await self._borrowed_iter._aclose_wrapper()  # type: ignore
@@ -362,7 +362,7 @@ def sync(function: Callable[..., Any], /) -> Callable[..., Any]:
     async def async_wrapped(*args: Any, **kwargs: Any) -> Any:
         result = function(*args, **kwargs)
         if isinstance(result, Awaitable):
-            return await result  # type: ignore
+            return await result  # pyright: ignore[reportUnknownVariableType]
         return result
 
     return async_wrapped

--- a/asyncstdlib/asynctools.py
+++ b/asyncstdlib/asynctools.py
@@ -172,10 +172,9 @@ def scoped_iter(iterable: AnyIterable[T]) -> AsyncContextManager[AsyncIterator[T
     closing the underlying iterator in favour of the outermost scope. This allows
     passing the scoped iterator to other functions that use :py:func:`scoped_iter`.
     """
-    iterator = aiter(iterable)
     # The iterable cannot be closed.
     # We do not need to take care of it.
-    if not hasattr(iterator, "aclose"):
+    if not hasattr(iterator := aiter(iterable), "aclose"):
         return nullcontext(iterator)
     # `iterator` might be already borrowed. We must not special-case this as:
     # - we cannot unwrap the underlying iterator, as this would give us longer access

--- a/asyncstdlib/asynctools.py
+++ b/asyncstdlib/asynctools.py
@@ -325,7 +325,7 @@ def sync(function: Callable[..., T]) -> Callable[..., Awaitable[T]]:
     ...
 
 
-def sync(function: Callable[..., T]) -> Callable[..., Any]:
+def sync(function: Callable[..., Any]) -> Callable[..., Any]:
     r"""
     Wraps a callable to ensure its result can be ``await``\ ed
 
@@ -353,6 +353,11 @@ def sync(function: Callable[..., T]) -> Callable[..., Any]:
 
         if __name__ == "__main__":
             asyncio.run(main())
+
+    .. note::
+
+        This should never be applied as the sole decorator on a function.
+        Define the function as `async def` instead.
     """
     if not callable(function):
         raise TypeError("function argument should be Callable")
@@ -361,7 +366,7 @@ def sync(function: Callable[..., T]) -> Callable[..., Any]:
         return function
 
     @wraps(function)
-    async def async_wrapped(*args: Any, **kwargs: Any) -> T:
+    async def async_wrapped(*args: Any, **kwargs: Any) -> Any:
         result = function(*args, **kwargs)
         if isinstance(result, Awaitable):
             return await result  # type: ignore

--- a/asyncstdlib/builtins.py
+++ b/asyncstdlib/builtins.py
@@ -271,7 +271,7 @@ async def _zip_inner_strict(
     tried = 0
     try:
         while True:
-            items = []
+            items: _sync_builtins.list[T] = []
             for tried, _aiter in _sync_builtins.enumerate(aiters):  # noqa: B007
                 items.append(await anext(_aiter))
             yield (*items,)
@@ -756,4 +756,4 @@ async def sorted(
         async_key = _awaitify(key)
         keyed_items = [(await async_key(item), item) async for item in aiter(iterable)]
         keyed_items.sort(key=lambda ki: ki[0], reverse=reverse)
-        return [item for key, item in keyed_items]
+        return [item for _, item in keyed_items]

--- a/asyncstdlib/builtins.py
+++ b/asyncstdlib/builtins.py
@@ -280,7 +280,7 @@ async def _zip_inner_strict(
         if tried > 0:
             plural = " " if tried == 1 else "s 1-"
             raise ValueError(
-                f"zip() argument {tried+1} is shorter than argument{plural}{tried}"
+                f"zip() argument {tried + 1} is shorter than argument{plural}{tried}"
             ) from None
         # after the first iterable was empty, some later iterable may be not
         sentinel = object()
@@ -288,7 +288,7 @@ async def _zip_inner_strict(
             if await anext(_aiter, sentinel) is not sentinel:
                 plural = " " if tried == 1 else "s 1-"
                 raise ValueError(
-                    f"zip() argument {tried+1} is longer than argument{plural}{tried}"
+                    f"zip() argument {tried + 1} is longer than argument{plural}{tried}"
                 ) from None
         return
 

--- a/asyncstdlib/contextlib.py
+++ b/asyncstdlib/contextlib.py
@@ -17,7 +17,7 @@ import sys
 
 from ._typing import Protocol, AsyncContextManager, ContextManager, T, C
 from ._core import awaitify
-from ._utility import public_module, slot_get as _slot_get
+from ._utility import public_module
 
 
 AnyContextManager = Union[AsyncContextManager[T], ContextManager[T]]
@@ -311,16 +311,18 @@ class ExitStack:
             instead.
         """
         try:
-            aexit = _slot_get(exit, "__aexit__")
+            aexit = exit.__aexit__  # type: ignore
         except AttributeError:
             try:
-                aexit = awaitify(_slot_get(exit, "__exit__"))
+                aexit = awaitify(
+                    exit.__exit__,  # type: ignore
+                )
             except AttributeError:
                 assert callable(
                     exit
                 ), f"Expected (async) context manager or callable, got {exit}"
                 aexit = awaitify(exit)
-        self._exit_callbacks.append(aexit)
+        self._exit_callbacks.append(aexit)  # pyright: ignore[reportUnknownArgumentType]
         return exit
 
     def callback(self, callback: C, *args: Any, **kwargs: Any) -> C:
@@ -371,14 +373,16 @@ class ExitStack:
         either.
         """
         try:
-            aexit = _slot_get(cm, "__aexit__")
+            aexit = cm.__aexit__  # type: ignore
         except AttributeError:
-            aexit = awaitify(_slot_get(cm, "__exit__"))
-            context_value = _slot_get(cm, "__enter__")()
+            aexit = awaitify(
+                cm.__exit__,  # type: ignore
+            )
+            context_value = cm.__enter__()  # type: ignore
         else:
-            context_value = await _slot_get(cm, "__aenter__")()
-        self._exit_callbacks.append(aexit)
-        return context_value  # type: ignore
+            context_value = await cm.__aenter__()  # type: ignore
+        self._exit_callbacks.append(aexit)  # pyright: ignore[reportUnknownArgumentType]
+        return context_value  # pyright: ignore[reportUnknownVariableType]
 
     async def aclose(self) -> None:
         """

--- a/asyncstdlib/contextlib.py
+++ b/asyncstdlib/contextlib.py
@@ -334,7 +334,7 @@ class ExitStack:
         the exception handled by the stack. The callback is treated as
         :term:`async neutral`, i.e. it may be a synchronous function.
 
-        This method does not change its argument, and can be used as a context manager.
+        This method does not change its argument, and can be used as a decorator.
         """
         self._exit_callbacks.append(
             partial(self._aexit_callback, partial(awaitify(callback), *args, **kwargs))

--- a/asyncstdlib/functools.py
+++ b/asyncstdlib/functools.py
@@ -10,7 +10,7 @@ from typing import (
     overload,
 )
 
-from ._typing import T, AC, AnyIterable
+from ._typing import T, T1, T2, AC, AnyIterable
 from ._core import ScopedIter, awaitify as _awaitify, Sentinel
 from .builtins import anext
 from ._utility import public_module
@@ -158,6 +158,20 @@ class CachedProperty(Generic[T]):
 
 
 cached_property = CachedProperty
+
+
+@overload
+def reduce(
+    function: Callable[[T1, T2], T1], iterable: AnyIterable[T2], initial: T1
+) -> Coroutine[T1, Any, Any]:
+    ...
+
+
+@overload
+def reduce(
+    function: Callable[[T, T], T], iterable: AnyIterable[T]
+) -> Coroutine[T, Any, Any]:
+    ...
 
 
 async def reduce(

--- a/asyncstdlib/heapq.py
+++ b/asyncstdlib/heapq.py
@@ -27,14 +27,14 @@ class _KeyIter(Generic[LT]):
         reverse: bool,
         head_key: LT,
         key: Callable[[T], Awaitable[LT]],
-    ):
-        pass
+    ) -> None:
+        ...
 
     @overload
     def __init__(
         self, head: LT, tail: AsyncIterator[LT], reverse: bool, head_key: LT, key: None
-    ):
-        pass
+    ) -> None:
+        ...
 
     def __init__(
         self,
@@ -43,7 +43,7 @@ class _KeyIter(Generic[LT]):
         reverse: bool,
         head_key: LT,
         key: Any,
-    ):
+    ) -> None:
         self.head = head
         self.head_key = head_key
         self.tail = tail
@@ -58,14 +58,14 @@ class _KeyIter(Generic[LT]):
         reverse: bool,
         key: Callable[[T], Awaitable[LT]],
     ) -> "AsyncIterator[_KeyIter[LT]]":
-        pass
+        ...
 
     @overload
     @classmethod
     def from_iters(
         cls, iterables: Tuple[AnyIterable[LT], ...], reverse: bool, key: None
     ) -> "AsyncIterator[_KeyIter[LT]]":
-        pass
+        ...
 
     @classmethod
     async def from_iters(
@@ -202,9 +202,7 @@ async def _largest(
     key: Callable[[T], Awaitable[LT]],
     reverse: bool,
 ) -> List[T]:
-    ordered: Callable[[SupportsLT], SupportsLT] = (
-        ReverseLT if reverse else lambda x: x  # type: ignore
-    )
+    ordered: Callable[[LT], LT] = ReverseLT if reverse else lambda x: x  # type: ignore
     async with ScopedIter(iterable) as iterator:
         # assign an ordering to items to solve ties
         order_sign = -1 if reverse else 1

--- a/asyncstdlib/heapq.py
+++ b/asyncstdlib/heapq.py
@@ -13,7 +13,7 @@ import heapq as _heapq
 
 from .builtins import enumerate as a_enumerate, zip as a_zip
 from ._core import aiter, awaitify, ScopedIter, borrow
-from ._typing import AnyIterable, LT, T, SupportsLT
+from ._typing import AnyIterable, LT, T
 
 
 class _KeyIter(Generic[LT]):

--- a/asyncstdlib/itertools.py
+++ b/asyncstdlib/itertools.py
@@ -370,6 +370,8 @@ async def takewhile(
 class NoLock:
     """Dummy lock that provides the proper interface but no protection"""
 
+    __slots__ = ()
+
     async def __aenter__(self) -> None:
         pass
 
@@ -456,6 +458,8 @@ class Tee(Generic[T]):
     - e.g. an :py:class:`asyncio.Lock` instance in an :py:mod:`asyncio` application -
     and access is automatically synchronised.
     """
+
+    __slots__ = ("_iterator", "_buffers", "_children")
 
     def __init__(
         self,

--- a/asyncstdlib/itertools.py
+++ b/asyncstdlib/itertools.py
@@ -156,14 +156,8 @@ async def batched(iterable: AnyIterable[T], n: int) -> AsyncIterator[Tuple[T, ..
     if n < 1:
         raise ValueError("n must be at least one")
     async with ScopedIter(iterable) as item_iter:
-        # TODO: Use walrus when 3.8 is minimal version
-        # while batch := await atuple(islice(item_iter, n)):
-        while True:
-            batch = await atuple(islice(_borrow(item_iter), n))
-            if batch:
-                yield batch
-            else:
-                break
+        while batch := await atuple(islice(_borrow(item_iter), n)):
+            yield batch
 
 
 class chain(AsyncIterator[T]):

--- a/asyncstdlib/itertools.py
+++ b/asyncstdlib/itertools.py
@@ -198,7 +198,7 @@ class chain(AsyncIterator[T]):
     ):
         self._iterator = self._chain_iterator(iterables or _iterables)
         self._owned_iterators = tuple(
-            iterable
+            iterable  # type: ignore[misc]
             for iterable in iterables
             if isinstance(iterable, AsyncIterator) and isinstance(iterable, _ACloseable)
         )

--- a/asyncstdlib/itertools.py
+++ b/asyncstdlib/itertools.py
@@ -52,7 +52,7 @@ async def cycle(iterable: AnyIterable[T]) -> AsyncIterator[T]:
     """
     buffer: List[T] = []
     async with ScopedIter(iterable) as async_iter:
-        async for item in async_iter:  # type: T
+        async for item in async_iter:
             buffer.append(item)
             yield item
     if not buffer:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,8 +15,6 @@ classifiers = [
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.6",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
@@ -25,7 +23,7 @@ classifiers = [
 ]
 license = {"file" = "LICENSE"}
 keywords = ["async", "enumerate", "itertools", "builtins", "functools", "contextlib"]
-requires-python = "~=3.6"
+requires-python = "~=3.8"
 dependencies = ["typing_extensions; python_version<'3.8'"]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 license = {"file" = "LICENSE"}
 keywords = ["async", "enumerate", "itertools", "builtins", "functools", "contextlib"]
 requires-python = "~=3.8"
-dependencies = ["typing_extensions; python_version<'3.8'"]
+dependencies = []
 
 [project.optional-dependencies]
 test = [

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [flake8]
 statistics = True
 max-line-length = 80
-ignore = E501, B008, B011, B905, W503
+ignore = E501, B008, B011, B905, B950, W503
 select = C,E,F,W,B,B9
 exclude = docs,.svn,CVS,.bzr,.hg,.git,__pycache__,.tox,.eggs,*.egg

--- a/unittests/test_helpers.py
+++ b/unittests/test_helpers.py
@@ -1,25 +1,6 @@
-from asyncstdlib import _utility
 from asyncstdlib import _core
 
 from .utility import sync
-
-
-def test_slot_get():
-    class Slotted:
-        data = 3
-
-        def __neg__(self):
-            return -type(self).data
-
-    instance = Slotted()
-    assert _utility.slot_get(instance, "data") is instance.data
-    assert _utility.slot_get(instance, "__neg__")() == -instance
-    assert _utility.slot_get(instance, "__neg__")() == instance.__neg__()
-    data, neg = instance.data, -instance
-    instance.data = 4
-    instance.__neg__ = lambda self: 12
-    assert _utility.slot_get(instance, "data") is data
-    assert _utility.slot_get(instance, "__neg__")() == neg
 
 
 @sync

--- a/unittests/test_helpers.py
+++ b/unittests/test_helpers.py
@@ -5,6 +5,8 @@ from .utility import sync
 
 @sync
 async def test_scoped_iter_graceful():
+    """Test that ScopedIter handlers non-generator iterables"""
+
     class AIterator:
         async def __anext__(self):
             return 1
@@ -20,5 +22,7 @@ async def test_scoped_iter_graceful():
     async with _core.ScopedIter(async_iterable) as async_iterator:
         # test that no error from calling the missing `aclose` is thrown
         assert async_iterator is not async_iterable
+        # check that the iterator satisfies iter(iterator) is iterator
+        assert _core.aiter(async_iterator) is async_iterator
         assert (await async_iterator.__anext__()) == 1
     assert (await async_iterator.__anext__()) == 1


### PR DESCRIPTION
- [x] Remove Py3.6 and Py3.7 from automation workflows.
- [x] Remove Py3.6 and Py3.7 from package metadata.
- [x] Remove `typing_extensions` dependency.
- Various general cleanup as part of reviewing all modules:
  - [x] remove use of `slot_get` helper (closes #78)
  - [x] improved type inference for `reduce` function arguments
  - [x] improved typing (and ignores) to better cover Pylance in addition to MyPy

Closes #95.