### PR TITLE
Fix tests stubs

### DIFF
--- a/asyncstdlib/_typing.py
+++ b/asyncstdlib/_typing.py
@@ -69,7 +69,7 @@ ADD = TypeVar("ADD", bound="SupportsAdd")
 
 
 class SupportsAdd(Protocol):
-    def __add__(self: ADD, other: ADD) -> ADD:
+    def __add__(self: ADD, other: ADD, /) -> ADD:
         raise NotImplementedError
 
 

--- a/asyncstdlib/itertools.pyi
+++ b/asyncstdlib/itertools.pyi
@@ -63,18 +63,16 @@ class chain(AsyncIterator[T]):
     async def aclose(self) -> None: ...
 
 def compress(data: AnyIterable[T], selectors: AnyIterable[Any]) -> AsyncIterator[T]: ...
-async def dropwhile(
+def dropwhile(
     predicate: Callable[[T], Any], iterable: AnyIterable[T]
 ) -> AsyncIterator[T]: ...
-async def filterfalse(
+def filterfalse(
     predicate: Callable[[T], Any] | None, iterable: AnyIterable[T]
 ) -> AsyncIterator[T]: ...
 @overload
-async def islice(
-    iterable: AnyIterable[T], start: int | None, /
-) -> AsyncIterator[T]: ...
+def islice(iterable: AnyIterable[T], start: int | None, /) -> AsyncIterator[T]: ...
 @overload
-async def islice(
+def islice(
     iterable: AnyIterable[T],
     start: int | None,
     stop: int | None,
@@ -82,34 +80,34 @@ async def islice(
     /,
 ) -> AsyncIterator[T]: ...
 @overload
-async def starmap(
+def starmap(
     function: Callable[[T1], T] | Callable[[T1], Awaitable[T]],
     iterable: AnyIterable[tuple[T1]],
 ) -> AsyncIterator[T]: ...
 @overload
-async def starmap(
+def starmap(
     function: Callable[[T1, T2], T] | Callable[[T1, T2], Awaitable[T]],
     iterable: AnyIterable[tuple[T1, T2]],
 ) -> AsyncIterator[T]: ...
 @overload
-async def starmap(
+def starmap(
     function: Callable[[T1, T2, T3], T] | Callable[[T1, T2, T3], Awaitable[T]],
     iterable: AnyIterable[tuple[T1, T2, T3]],
 ) -> AsyncIterator[T]: ...
 @overload
-async def starmap(
+def starmap(
     function: Callable[[T1, T2, T3, T4], T] | Callable[[T1, T2, T3, T4], Awaitable[T]],
     iterable: AnyIterable[tuple[T1, T2, T3, T4]],
 ) -> AsyncIterator[T]: ...
 @overload
-async def starmap(
+def starmap(
     function: (
         Callable[[T1, T2, T3, T4, T5], T] | Callable[[T1, T2, T3, T4, T5], Awaitable[T]]
     ),
     iterable: AnyIterable[tuple[T1, T2, T3, T4, T5]],
 ) -> AsyncIterator[T]: ...
 @overload
-async def starmap(
+def starmap(
     function: Callable[..., T] | Callable[..., Awaitable[T]],
     iterable: AnyIterable[Iterable[Any]],
 ) -> AsyncIterator[T]: ...

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ typetest = [
     "mypy; implementation_name=='cpython'",
     "pyright",
     "typing-extensions",
+    "mypy-typing-asserts",
 ]
 doc = ["sphinx", "sphinxcontrib-trio"]
 
@@ -52,6 +53,7 @@ Source = "https://github.com/maxfischer2781/asyncstdlib"
 include = ["unittests"]
 
 [tool.mypy]
+plugins = ["mypy_typing_asserts.mypy_plugin"]
 files = ["asyncstdlib", "typetests"]
 check_untyped_defs = true
 no_implicit_optional = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,6 @@ typetest = [
     "mypy; implementation_name=='cpython'",
     "pyright",
     "typing-extensions",
-    "mypy-typing-asserts",
 ]
 doc = ["sphinx", "sphinxcontrib-trio"]
 
@@ -53,7 +52,6 @@ Source = "https://github.com/maxfischer2781/asyncstdlib"
 include = ["unittests"]
 
 [tool.mypy]
-plugins = ["mypy_typing_asserts.mypy_plugin"]
 files = ["asyncstdlib", "typetests"]
 check_untyped_defs = true
 no_implicit_optional = true

--- a/typetests/test_itertools.py
+++ b/typetests/test_itertools.py
@@ -1,0 +1,71 @@
+from typing import AsyncIterator
+from asyncstdlib import itertools
+from typing_extensions import assert_type
+
+
+async def test_cycle() -> None:
+    async for x in itertools.cycle([1]):
+        assert_type(x, int)
+
+
+async def test_accumulate() -> None:
+    async for x in itertools.accumulate([1]):
+        assert_type(x, int)
+
+
+async def test_batched() -> None:
+    async for x in itertools.batched([1], 1):
+        assert_type(x, "tuple[int]")
+
+
+async def test_chain() -> None:
+    async for x in itertools.chain([1]):
+        assert_type(x, int)
+
+
+async def test_compress() -> None:
+    async for x in itertools.compress([1], [1]):
+        assert_type(x, int)
+
+
+async def test_dropwhile() -> None:
+    async for x in itertools.dropwhile(lambda x: True, [1]):
+        assert_type(x, int)
+
+
+async def test_filterfalse() -> None:
+    async for x in itertools.filterfalse(lambda x: True, [1]):
+        assert_type(x, int)
+
+
+async def test_starmap() -> None:
+    def f(x: str) -> int:
+        return int(x)
+
+    async for x in itertools.starmap(f, [("1",)]):
+        assert_type(x, int)
+
+
+async def test_takewhile() -> None:
+    async for x in itertools.takewhile(lambda x: True, [1]):
+        assert_type(x, int)
+
+
+async def test_tee() -> None:
+    async for x in itertools.tee([1])[0]:
+        assert_type(x, int)
+
+
+async def test_pairwise() -> None:
+    async for x in itertools.pairwise([1]):
+        assert_type(x, "tuple[int, int]")
+
+
+async def test_zip_longest() -> None:
+    async for x in itertools.zip_longest([1]):
+        assert_type(x, "tuple[int]")
+
+
+async def test_groupby() -> None:
+    async for x in itertools.groupby([1]):
+        assert_type(x, "tuple[int, AsyncIterator[int]]")


### PR DESCRIPTION
The current typing yield the following error:

```
error: "Coroutine[Any, Any, AsyncIterator[Any]]" has no attribute "__aiter__" (not async iterable)  [attr-defined]
```

Related to https://github.com/python/mypy/issues/10301

I also took time to add a typing test for every function in itertools that validate the iterator type. I added a dependency to `mypy-type-assets` to easily assert the type.