### PR TITLE
fix type annotation from static checks 597

### DIFF
--- a/asyncstdlib/asynctools.py
+++ b/asyncstdlib/asynctools.py
@@ -10,6 +10,7 @@ from typing import (
     Awaitable,
     AsyncIterable,
     Callable,
+    Coroutine,
     Any,
     overload,
     Optional,
@@ -76,7 +77,7 @@ class _BorrowedAsyncIterator(AsyncGenerator[T, S]):
         if hasattr(self, "athrow"):
             self.athrow = wrapper_iterator.athrow
 
-    def aclose(self) -> Awaitable[None]:
+    def aclose(self) -> Coroutine[Any, Any, None]:
         return self._aclose_wrapper()
 
 


### PR DESCRIPTION
This PR fixes the [Static Checks #597](https://github.com/maxfischer2781/asyncstdlib/actions/runs/9919159328) report:

```
asyncstdlib/asynctools.py#L79
Method "aclose" overrides class "AsyncGenerator" in an incompatible manner
  Return type mismatch: base method returns type "Coroutine[Any, Any, None]", override returns type "Awaitable[None]"
    "Awaitable[None]" is incompatible with "Coroutine[Any, Any, None]" (reportIncompatibleMethodOverride)
```

The report is correct and code has been adjusted accordingly.