### PR TITLE
Fix type checker disagreement (GH action 790)

### DIFF
--- a/asyncstdlib/asynctools.py
+++ b/asyncstdlib/asynctools.py
@@ -35,7 +35,7 @@ class _BorrowedAsyncIterator(AsyncGenerator[T, S]):
     __slots__ = "__wrapped__", "__anext__", "asend", "athrow", "_wrapper"
 
     # Type checker does not understand `__slot__` definitions
-    __anext__: Callable[[Any], Coroutine[Any, Any, T]]
+    __anext__: Callable[..., Coroutine[Any, Any, T]]
     asend: Any
     athrow: Any
 

--- a/asyncstdlib/asynctools.py
+++ b/asyncstdlib/asynctools.py
@@ -49,7 +49,7 @@ class _BorrowedAsyncIterator(AsyncGenerator[T, S]):
         # An async *iterator* (e.g. `async def: yield`) must return
         # itself from __aiter__. If we do not shadow this then
         # running aiter(self).aclose closes the underlying iterator.
-        self.__anext__ = self._wrapper.__anext__  # type: ignore
+        self.__anext__ = self._wrapper.__anext__
         if hasattr(iterator, "asend"):
             self.asend = (
                 iterator.asend  # pyright: ignore[reportUnknownMemberType,reportAttributeAccessIssue]


### PR DESCRIPTION
This PR fixes a mismatch from the recent MyPy disagreeing with PyRight about the arity of `__anext__`.